### PR TITLE
Add DM API generator and ability to include/exclude features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ percent-encoding = { version = "1.0", optional = true }
 png = { version = "0.11.0", optional = true }
 
 [features]
+default = ["dmi", "log"]
 dmi = ["png"]
 file = []
 hash = ["crypto-hash", "hex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,16 @@ opt-level = 3
 lto = true
 
 [dependencies]
-chrono = "0.4"
-crypto-hash = "0.3"
 failure = "0.1"
-hex = "0.3"
-percent-encoding = "1.0"
-png = "0.11.0"
+chrono = { version = "0.4", optional = true }
+crypto-hash = { version = "0.3", optional = true }
+hex = { version = "0.3", optional = true }
+percent-encoding = { version = "1.0", optional = true }
+png = { version = "0.11.0", optional = true }
+
+[features]
+dmi = ["png"]
+file = []
+hash = ["crypto-hash", "hex"]
+log = ["chrono"]
+url = ["percent-encoding"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ The [Rust] compiler:
    or run this command:
 
     ```sh
-    curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable
+    curl https://sh.rustup.rs -sSfo rustup-init.sh
+    chmod +x rustup-init.sh
+    ./rustup-init.sh
     ```
 
 1. Set the default compiler to **32-bit**:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,14 @@ this repo at your preference.
 
 The [Rust] compiler:
 
+1. Install the Rust compiler's dependencies (primarily the system linker):
+
+   * Ubuntu: `sudo apt-get install gcc-multilib`
+   * Windows (MSVC): [Build Tools for Visual Studio 2017][msvc]
+   * Windows (GNU): No action required
+
 1. Use [the Rust installer](https://rustup.rs/), or another Rust installation method,
-   or run this command:
+   or run the following:
 
     ```sh
     curl https://sh.rustup.rs -sSfo rustup-init.sh
@@ -36,7 +42,7 @@ OpenSSL (**Optional**, not required by the default configuration):
 * Ubuntu and Debian users run:
 
     ```sh
-    sudo apt-get install libssl-dev:i386 libssl1.0.0:i386 pkg-config gcc-multilib
+    sudo apt-get install libssl-dev:i386 pkg-config:i386
     ```
 
 * Other distributions install the appropriate **32-bit development** and **32-bit runtime** packages.
@@ -81,9 +87,8 @@ Compiling will also create the file `target/rust_g.dm` which contains the DM API
 of the enabled modules. To use rust-g, copy-paste this file into your project.
 
 It is also possible to automatically override the built-in versions of the
-functions being replaced, though this ability is not well-tested. To enable
-this, create and include `rust_g.config.dm` in the same directory you placed
-`rust_g.dm`, with the contents:
+functions being replaced. To enable this, create and include `rust_g.config.dm`
+in the same directory you placed `rust_g.dm`, with the contents:
 
 ```dm
 #define RUSTG_OVERRIDE_BUILTINS
@@ -98,7 +103,7 @@ build, make sure you are using the 32-bit Rust compiler. Correct output for a
 
 ```sh
 $ file rust_g  # Linux
-ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, BuildID[sha1]=..., not stripped
+ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, BuildID[sha1]=..., with debug_info, not stripped
 
 $ file rust_g.dll  # Windows
 PE32 executable (DLL) (GUI) Intel 80386 (stripped to external PDB), for MS Windows
@@ -129,6 +134,7 @@ If you're still having problems, ask in [tgstation]'s IRC, `#coderbus` on Rizon.
 [Rust]: https://rust-lang.org
 [cargo]: https://doc.rust-lang.org/cargo/
 [rustup]: https://rustup.rs/
+[msvc]: https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,35 +7,129 @@ This library is currently used in the [tgstation] codebase, and is required for 
 A pre-compiled DLL version can be found in the repo root, but you can build your own from
 this repo at your preference.
 
+## Dependencies
+
+The [Rust] compiler:
+
+1. Use [the Rust installer](https://rustup.rs/), or another Rust installation method,
+   or run this command:
+
+    ```sh
+    curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable
+    ```
+
+1. Set the default compiler to **32-bit**:
+
+    ```sh
+    # in the `rust-g` directory...
+    cd rust-g
+    # Linux
+    rustup override add stable-i686-unknown-linux-gnu
+    # Windows
+    rustup override add stable-i686-pc-windows-msvc
+    ```
+
+OpenSSL (**Optional**, not required by the default configuration):
+
+* Ubuntu and Debian users run:
+
+    ```sh
+    sudo apt-get install libssl-dev:i386 libssl1.0.0:i386 pkg-config gcc-multilib
+    ```
+
+* Other distributions install the appropriate **32-bit development** and **32-bit runtime** packages.
+
 ## Compiling
 
-rust-g is build with [Rust] as you might have guessed from the name. Install rust using
-[rustup] in order to build rust-g using [cargo] (as a release build, for speed):
+The [cargo] tool handles compilation, as well as automatically downloading and
+compiling all Rust dependencies. The default configuration is suitable for
+use with the [tgstation] codebase. To compile in release mode (recommended for
+speed):
 
-    cargo build --release
+```sh
+cargo build --release
+```
 
-All dependencies will automatically be downloaded and compiled. rust-g should be compilable on
-both Rust stable and nightly.
+On Linux, the output will be `target/release/librust_g.so`, but **must be renamed**
+to `rust_g` to install correctly.
 
-You will find your `.so` or `.dll` in `targets/release`. More advanced users can
-cross-compile rust-g using cargo (but this is beyond the scope of a README).
+On Windows, the output will be `target/release/rust_g.dll`.
+
+For more advanced configuration, a list of modules may be passed:
+
+```sh
+cargo build --release --features dmi,file,log,url
+```
+
+* **dmi** (default): DMI manipulations which are impossible from within BYOND.
+  Used by the asset cache subsystem to improve load times.
+* file: Faster replacements for `file2text` and `text2file`.
+* hash: Faster replacement for `md5`, support for SHA-1, SHA-256, and SHA-512. Requires OpenSSL on Linux.
+* **log** (default): Faster log output.
+* url: Faster replacements for `url_encode` and `url_decode`.
 
 ## Installing
 
-rust-g needs to be installed to your BYOND bin folder (to run in trusted mode), or
-the root of your repository (next to your `.dmb`).
+The rust-g binary needs to be copied to either your BYOND bin folder, or to the
+root of the repository (next to your `.dmb`).
 
-Linux users should symlink or rename `librust_g.so` to `rust_g` in order for BYOND
-to correctly resolve the library.
+On Linux, be sure the file is named `rust_g`.
 
+Compiling will also create the file `target/rust_g.dm` which contains the DM API
+of the enabled modules. To use rust-g, copy-paste this file into your project.
+
+It is also possible to automatically override the built-in versions of the
+functions being replaced, though this ability is not well-tested. To enable
+this, create and include `rust_g.config.dm` in the same directory you placed
+`rust_g.dm`, with the contents:
+
+```dm
+#define RUSTG_OVERRIDE_BUILTINS
+```
+
+## Troubleshooting
+
+The most common mistake is building a 64-bit version of the library, which BYOND
+will be unable to load. If the output of the `file` command indicates a 64-bit
+build, make sure you are using the 32-bit Rust compiler. Correct output for a
+32-bit build will look similar to:
+
+```sh
+$ file rust_g  # Linux
+ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, BuildID[sha1]=..., not stripped
+
+$ file rust_g.dll  # Windows
+PE32 executable (DLL) (GUI) Intel 80386 (stripped to external PDB), for MS Windows
+```
+
+On Linux systems where the `hash` module is in use, `ldd` can be used to check
+that the OpenSSL runtime libraries are installed, without which BYOND will fail
+to load rust-g. Use the `ldd` command to check that the dependencies are being
+found, and no libraries are missing:
+
+```sh
+$ ldd rust_g  # Linux
+        linux-gate.so.1 =>  (0xf7775000)
+        libssl.so.1.0.0 => /lib/i386-linux-gnu/libssl.so.1.0.0 (0xf7677000)
+        libcrypto.so.1.0.0 => /lib/i386-linux-gnu/libcrypto.so.1.0.0 (0xf748a000)
+        libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf7485000)
+        librt.so.1 => /lib/i386-linux-gnu/librt.so.1 (0xf747c000)
+        libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf745e000)
+        libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf7441000)
+        libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf728b000)
+        /lib/ld-linux.so.2 (0x5657d000)
+        libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf7236000)
+```
+
+If you're still having problems, ask in [tgstation]'s IRC, `#coderbus` on Rizon.
 
 [tgstation]: https://github.com/tgstation/tgstation
 [Rust]: https://rust-lang.org
 [cargo]: https://doc.rust-lang.org/cargo/
 [rustup]: https://rustup.rs/
 
-## LICENSE
+## License
 
-This project is licensed under the [MIT](https://en.wikipedia.org/wiki/MIT_License) license.
+This project is licensed under the [MIT license](https://en.wikipedia.org/wiki/MIT_License).
 
-See LICENSE for more details.
+See [LICENSE](./LICENSE) for more details.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,61 @@
+//! Buildscript which will save a `rust_g.dm` with the DLL's public API.
+
+use std::io::Write;
+use std::fs::File;
+
+fn main() {
+    let mut f = File::create("target/rust_g.dm").unwrap();
+
+    // header
+    write!(f, r#"// rust_g.dm - DM API for rust_g extension library
+#define RUST_G "rust_g"
+"#).unwrap();
+
+    // module: dmi
+    write!(f, r#"
+#define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
+"#).unwrap();
+
+    // module: file
+    write!(f, r#"
+#define rustg_file_read(fname) call(RUST_G, "file_read")(fname)
+#define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, fname)
+
+#ifdef RUSTG_OVERRIDE_BUILTINS
+#define file2text(fname) rustg_file_read(fname)
+#define text2file(text, fname) rustg_file_write(text, fname)
+#endif
+"#).unwrap();
+
+    // module: hash
+    write!(f, r#"
+#define rustg_hash_string(algorithm, text) call(RUST_G, "hash_string")(algorithm, text)
+#define rustg_hash_file(algorithm, fname) call(RUST_G, "hash_file")(algorithm, fname)
+
+#define RUSTG_HASH_MD5 "md5"
+#define RUSTG_HASH_SHA1 "sha1"
+#define RUSTG_HASH_SHA256 "sha256"
+#define RUSTG_HASH_SHA512 "sha512"
+
+#ifdef RUSTG_OVERRIDE_BUILTINS
+#define md5(thing) (isfile(thing) ? rustg_hash_file(RUSTG_HASH_MD5, "[thing]") : rustg_hash_string(RUSTG_HASH_MD5, thing))
+#endif
+"#).unwrap();
+
+    // module: log
+    write!(f, r#"
+#define rustg_log_write(fname, text) call(RUST_G, "log_write")(fname, text)
+#define rustg_log_close_all() call(RUST_G, "log_close_all")()
+"#).unwrap();
+
+    // module: url
+    write!(f, r#"
+#define rustg_url_encode(text) call(RUST_G, "url_encode")(text)
+#define rustg_url_decode(text) call(RUST_G, "url_decode")(text)
+
+#ifdef RUSTG_OVERRIDE_BUILTINS
+#define url_encode(text) rustg_url_encode(text)
+#define url_decode(text) rustg_url_decode(text)
+#endif
+"#).unwrap();
+}

--- a/build.rs
+++ b/build.rs
@@ -58,7 +58,7 @@ fn main() {
     if enabled!("LOG") {
         write!(f, r#"
 #define rustg_log_write(fname, text) call(RUST_G, "log_write")(fname, text)
-#define rustg_log_close_all() call(RUST_G, "log_close_all")()
+/proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
 "#).unwrap();
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,8 +22,7 @@ pub enum Error {
     #[cfg(feature="png")]
     #[fail(display = "{}", _0)]
     ImageDecoding(#[cause] DecodingError),
-
-#[cfg(feature="png")]
+    #[cfg(feature="png")]
     #[fail(display = "{}", _0)]
     ImageEncoding(#[cause] EncodingError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::result;
 use std::str::Utf8Error;
 
+#[cfg(feature="png")]
 use png::{DecodingError, EncodingError};
 
 pub type Result<T> = result::Result<T, Error>;
@@ -18,8 +19,11 @@ pub enum Error {
     Io(#[cause] io::Error),
     #[fail(display = "Invalid algorithm specified.")]
     InvalidAlgorithm,
+    #[cfg(feature="png")]
     #[fail(display = "{}", _0)]
     ImageDecoding(#[cause] DecodingError),
+
+#[cfg(feature="png")]
     #[fail(display = "{}", _0)]
     ImageEncoding(#[cause] EncodingError),
 }
@@ -36,12 +40,14 @@ impl From<Utf8Error> for Error {
     }
 }
 
+#[cfg(feature="png")]
 impl From<DecodingError> for Error {
     fn from(error: DecodingError) -> Error {
         Error::ImageDecoding(error)
     }
 }
 
+#[cfg(feature="png")]
 impl From<EncodingError> for Error {
     fn from(error: EncodingError) -> Error {
         Error::ImageEncoding(error)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,28 @@
-extern crate chrono;
-extern crate crypto_hash;
 #[macro_use]
 extern crate failure;
+
+#[cfg(feature="chrono")]
+extern crate chrono;
+#[cfg(feature="crypto-hash")]
+extern crate crypto_hash;
+#[cfg(feature="hex")]
 extern crate hex;
+#[cfg(feature="percent-encoding")]
 extern crate percent_encoding;
+#[cfg(feature="png")]
 extern crate png;
 
 #[macro_use]
 mod byond;
-pub mod dmi;
 mod error;
+
+#[cfg(feature="dmi")]
+pub mod dmi;
+#[cfg(feature="file")]
 pub mod file;
+#[cfg(feature="hash")]
 pub mod hash;
+#[cfg(feature="log")]
 pub mod log;
+#[cfg(feature="url")]
 pub mod url;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate png;
 
 #[macro_use]
 mod byond;
+#[allow(dead_code)]
 mod error;
 
 #[cfg(feature="dmi")]


### PR DESCRIPTION
Prelude to adding some new functionality. Closes #4.

* Adds Cargo features, allowing consumers to exclude unused portions of the library
  * `cargo build --release --all-features` to get everything
  * `cargo build --release --features dmi,log` to get what /tg/ is currently using
* Adds a DM API file which can be placed into a project
  * Only includes calls from enabled features
  * Observes `RUSTG_OVERRIDE_BUILTINS` define to use rust_g instead of some builtins

Example of `rust_g.dm` when `--all-features` is used (not yet thoroughly tested):

```dm
// rust_g.dm - DM API for rust_g extension library
#define RUST_G "rust_g"

#define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)

#define rustg_file_read(fname) call(RUST_G, "file_read")(fname)
#define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, fname)

#ifdef RUSTG_OVERRIDE_BUILTINS
#define file2text(fname) rustg_file_read(fname)
#define text2file(text, fname) rustg_file_write(text, fname)
#endif

#define rustg_hash_string(algorithm, text) call(RUST_G, "hash_string")(algorithm, text)
#define rustg_hash_file(algorithm, fname) call(RUST_G, "hash_file")(algorithm, fname)

#define RUSTG_HASH_MD5 "md5"
#define RUSTG_HASH_SHA1 "sha1"
#define RUSTG_HASH_SHA256 "sha256"
#define RUSTG_HASH_SHA512 "sha512"

#ifdef RUSTG_OVERRIDE_BUILTINS
#define md5(thing) (isfile(thing) ? rustg_hash_file(RUSTG_HASH_MD5, "[thing]") : rustg_hash_string(RUSTG_HASH_MD5, thing))
#endif

#define rustg_log_write(fname, text) call(RUST_G, "log_write")(fname, text)
/proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()

#define rustg_url_encode(text) call(RUST_G, "url_encode")(text)
#define rustg_url_decode(text) call(RUST_G, "url_decode")(text)

#ifdef RUSTG_OVERRIDE_BUILTINS
#define url_encode(text) rustg_url_encode(text)
#define url_decode(text) rustg_url_decode(text)
#endif
