### PR TITLE
Add git module for reading revision info with libgit2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,13 @@ crypto-hash = { version = "0.3", optional = true }
 hex = { version = "0.3", optional = true }
 percent-encoding = { version = "1.0", optional = true }
 png = { version = "0.11.0", optional = true }
+git2 = { version = "0.7.1", optional = true, default-features = false }
 
 [features]
-default = ["dmi", "log"]
+default = ["dmi", "log", "git"]
 dmi = ["png"]
 file = []
 hash = ["crypto-hash", "hex"]
 log = ["chrono"]
 url = ["percent-encoding"]
+git = ["git2", "chrono"]

--- a/build.rs
+++ b/build.rs
@@ -40,8 +40,8 @@ fn main() {
     // module: git
     if enabled!("GIT") {
         write!(f, r#"
-#define rustg_git_rev_parse(rev) call(RUST_G, "git_rev_parse")(rev)
-#define rustg_git_commit_date(rev) call(RUST_G, "git_commit_date")(rev)
+#define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)
+#define rustg_git_commit_date(rev) call(RUST_G, "rg_git_commit_date")(rev)
 "#).unwrap();
     }
 

--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,14 @@ fn main() {
 "#).unwrap();
     }
 
+    // module: git
+    if enabled!("GIT") {
+        write!(f, r#"
+#define rustg_git_rev_parse(rev) call(RUST_G, "git_rev_parse")(rev)
+#define rustg_git_commit_date(rev) call(RUST_G, "git_commit_date")(rev)
+"#).unwrap();
+    }
+
     // module: hash
     if enabled!("HASH") {
         write!(f, r#"

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,24 @@
+use git2::{Repository, Error, ErrorCode};
+use chrono::{Utc, TimeZone};
+
+thread_local! {
+    static REPOSITORY: Result<Repository, Error> = Repository::open(".");
+}
+
+byond_fn! { git_rev_parse(rev) {
+    REPOSITORY.with(|repo| -> Result<String, ErrorCode> {
+        let repo = repo.as_ref().map_err(Error::code)?;
+        let object = repo.revparse_single(rev).map_err(|e| e.code())?;
+        Ok(object.id().to_string())
+    }).ok()
+} }
+
+byond_fn! { git_commit_date(rev) {
+    REPOSITORY.with(|repo| -> Result<String, ErrorCode> {
+        let repo = repo.as_ref().map_err(Error::code)?;
+        let object = repo.revparse_single(rev).map_err(|e| e.code())?;
+        let commit = object.as_commit().ok_or(ErrorCode::GenericError)?;
+        let datetime = Utc.timestamp(commit.time().seconds(), 0);
+        Ok(datetime.format("%F").to_string())
+    }).ok()
+} }

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,7 +5,7 @@ thread_local! {
     static REPOSITORY: Result<Repository, Error> = Repository::open(".");
 }
 
-byond_fn! { git_rev_parse(rev) {
+byond_fn! { rg_git_revparse(rev) {
     REPOSITORY.with(|repo| -> Result<String, ErrorCode> {
         let repo = repo.as_ref().map_err(Error::code)?;
         let object = repo.revparse_single(rev).map_err(|e| e.code())?;
@@ -13,7 +13,7 @@ byond_fn! { git_rev_parse(rev) {
     }).ok()
 } }
 
-byond_fn! { git_commit_date(rev) {
+byond_fn! { rg_git_commit_date(rev) {
     REPOSITORY.with(|repo| -> Result<String, ErrorCode> {
         let repo = repo.as_ref().map_err(Error::code)?;
         let object = repo.revparse_single(rev).map_err(|e| e.code())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ extern crate failure;
 extern crate chrono;
 #[cfg(feature="crypto-hash")]
 extern crate crypto_hash;
+#[cfg(feature="git2")]
+extern crate git2;
 #[cfg(feature="hex")]
 extern crate hex;
 #[cfg(feature="percent-encoding")]
@@ -21,6 +23,8 @@ mod error;
 pub mod dmi;
 #[cfg(feature="file")]
 pub mod file;
+#[cfg(feature="git")]
+pub mod git;
 #[cfg(feature="hash")]
 pub mod hash;
 #[cfg(feature="log")]


### PR DESCRIPTION
Lets us get revision info without parsing files in the `.git/` directory, poorly.

Marked as default because /tg/station will be using it in a forthcoming PR.