### PR TITLE
Only timestamp the first line of a log entry

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -15,11 +15,28 @@ thread_local! {
 }
 
 byond_fn! { log_write(path, data) {
-    data.split('\n')
-        .map(|line| format(line))
-        .map(|line| write(path, line))
-        .collect::<Result<Vec<_>>>()
-        .err()
+    FILE_MAP.with(|cell| -> Result<()> {
+        // open file
+        let mut map = cell.borrow_mut();
+        let path = Path::new(&path as &str);
+        let file = match map.entry(filename(path)?) {
+            Entry::Occupied(elem) => elem.into_mut(),
+            Entry::Vacant(elem) => elem.insert(open(path)?),
+        };
+
+        // write first line, timestamped
+        let mut iter = data.split('\n');
+        if let Some(line) = iter.next() {
+            write!(file, "[{}] {}\n", Utc::now().format("%F %T%.3f"), line)?;
+        }
+
+        // write remaining lines
+        for line in iter {
+            write!(file, " - {}\n", line);
+        }
+
+        Ok(())
+    }).err()
 } }
 
 byond_fn! { log_close_all()! {
@@ -28,23 +45,6 @@ byond_fn! { log_close_all()! {
         map.clear();
     })
 } }
-
-fn format(data: &str) -> String {
-    format!("[{}] {}\n", Utc::now().format("%F %T%.3f"), data)
-}
-
-fn write(path: &str, data: String) -> Result<usize> {
-    FILE_MAP.with(|cell| {
-        let mut map = cell.borrow_mut();
-        let path = Path::new(path);
-        let file = match map.entry(filename(path)?) {
-            Entry::Occupied(elem) => elem.into_mut(),
-            Entry::Vacant(elem) => elem.insert(open(path)?),
-        };
-
-        Ok(file.write(&data.into_bytes())?)
-    })
-}
 
 fn filename(path: &Path) -> Result<OsString> {
     match path.file_name() {


### PR DESCRIPTION
Requested by @MrStonedOne.

Right now, if a line starts with "WARNING:", there's no way to tell whether it's an actual warning or part of an admin-generated Command Report:

```
[2018-10-19 22:22:57.426] ADMIN: SpaceManiac/(SpaceManiac) has created a command report: A warning from Command follows:
[2018-10-19 22:22:57.426] WARNING: ling in maint
```

Instead, let's only timestamp the first line, and precede other lines with a continuation marker ` - `.

<details>
<summary>Startup runtime log example</summary>

```
[2018-10-19 22:21:23.392] Starting up round ID .
 - -------------------------
[2018-10-19 22:21:23.400] Running /tg/ revision: 2018-10-19
 - origin/master: 5b00956b414d68c3bb408dbf037db4511a09c8ff
 - HEAD: f66e311ebcd05ac29ae5df37dfb39fdfe548d856
[2018-10-19 22:21:25.682] Initialized Title Screen subsystem within 0.1 seconds!
[2018-10-19 22:21:25.690] Initialized Database subsystem within 0 seconds!
[2018-10-19 22:21:25.694] Initialized Blackbox subsystem within 0 seconds!
[2018-10-19 22:21:25.699] Initialized Server Tasks subsystem within 0 seconds!
[2018-10-19 22:21:25.704] Initialized Input subsystem within 0 seconds!
[2018-10-19 22:21:25.708] Initialized Vis contents overlays subsystem within 0 seconds!
[2018-10-19 22:21:25.736] Initialized Research subsystem within 0 seconds!
[2018-10-19 22:21:25.747] Initialized Events subsystem within 0 seconds!
[2018-10-19 22:21:25.756] Initialized Jobs subsystem within 0 seconds!
[2018-10-19 22:21:25.761] Initialized Quirks subsystem within 0 seconds!
[2018-10-19 22:21:25.880] Initialized Ticker subsystem within 0.1 seconds!
[2018-10-19 22:21:25.888] Loading Runtime Station...
[2018-10-19 22:21:26.137] Loaded Station in 0.3s!
[2018-10-19 22:21:32.684] Initialized Mapping subsystem within 6.8 seconds!
[2018-10-19 22:21:32.693] Initialized Networks subsystem within 0 seconds!
[2018-10-19 22:21:32.698] Initialized Economy subsystem within 0 seconds!
[2018-10-19 22:21:37.107] runtime error: pick() from empty list
 - proc name: Initialize (/obj/docking_port/stationary/random/Initialize)
 -   source file: emergency.dm,485
 -   usr: null
 -   src: the lavaland (/obj/docking_port/stationary/random)
 -   src.loc: space (22,74,2) (/turf/open/space)
 -   call stack:
 - the lavaland (/obj/docking_port/stationary/random): Initialize(1)
 - Atoms (/datum/controller/subsystem/atoms): InitAtom(the lavaland (/obj/docking_port/stationary/random), /list (/list))
 - Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(null)
 - Atoms (/datum/controller/subsystem/atoms): Initialize(804927)
 - Master (/datum/controller/master): Initialize(10, 0, 1)
 - 
[2018-10-19 22:21:40.051] Initialized Atoms subsystem within 7.3 seconds!
[2018-10-19 22:21:40.068] Initialized Language subsystem within 0 seconds!
[2018-10-19 22:21:40.078] Initialized Machines subsystem within 0 seconds!
[2018-10-19 22:21:40.124] Initialized Circuit subsystem within 0.1 seconds!
[2018-10-19 22:21:40.132] Initialized Disease subsystem within 0 seconds!
[2018-10-19 22:21:40.139] Initialized Medals subsystem within 0 seconds!
[2018-10-19 22:21:40.144] Initialized Night Shift subsystem within 0 seconds!
[2018-10-19 22:21:40.151] Initialized Parallax subsystem within 0 seconds!
[2018-10-19 22:21:40.291] Initialized Traumas subsystem within 0.1 seconds!
[2018-10-19 22:21:40.299] Initialized Weather subsystem within 0 seconds!
[2018-10-19 22:21:41.063] Initialized Atmospherics subsystem within 0.7 seconds!
[2018-10-19 22:21:44.563] Initialized Assets subsystem within 3.5 seconds!
[2018-10-19 22:21:44.902] Initialized Icon Smoothing subsystem within 0.4 seconds!
[2018-10-19 22:21:45.007] Initialized Overlay subsystem within 0.1 seconds!
[2018-10-19 22:21:45.012] Initialized XKeyScore subsystem within 0 seconds!
[2018-10-19 22:21:45.385] Initialized Sticky Ban subsystem within 0.3 seconds!
[2018-10-19 22:21:46.365] Initialized Lighting subsystem within 1 second!
[2018-10-19 22:21:47.801] Initialized Shuttle subsystem within 1.5 seconds!
[2018-10-19 22:21:47.827] Initialized Squeak subsystem within 0 seconds!
[2018-10-19 22:21:47.844] Initialized Pathfinder subsystem within 0 seconds!
[2018-10-19 22:21:47.938] Loaded 0 engraved messages on map Runtime Station
[2018-10-19 22:21:47.955] Initialized Persistence subsystem within 0.1 seconds!
[2018-10-19 22:21:47.961] Initializations complete within 22.4 seconds!
```

</details>