### PR TITLE
Fix an unused-Result warning

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -32,7 +32,7 @@ byond_fn! { log_write(path, data) {
 
         // write remaining lines
         for line in iter {
-            write!(file, " - {}\n", line);
+            write!(file, " - {}\n", line)?;
         }
 
         Ok(())


### PR DESCRIPTION
```
warning: unused `std::result::Result` that must be used
  --> src\log.rs:35:13
   |
35 |             write!(file, " - {}\n", line);
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(unused_must_use)] on by default
   = note: this `Result` may be an `Err` variant, which should be handled
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```