### PR TITLE
Bump version to 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-g"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Bjorn Neergaard <bjorn@neersighted.com>"]
 repository = "https://github.com/tgstation/rust-g"
 license-file = "LICENSE"


### PR DESCRIPTION
pre-changelog:

* 3209c8c Fix an unused-Result warning
* 0b8677e Add Cargo.lock
* f739692 Only timestamp the first line of a log entry
* a3be105 Test non-default features on Travis as well (#14)
* af240a9 Add append function (#12)
* 40d8189 Add LD_LIBRARY_PATH advice to the readme (#11)