### PR TITLE
Add missing step

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The [Rust] compiler:
 1. Set the default compiler to **32-bit**:
 
     ```sh
-    # Clone the `rust-g` to a directory of your choise
+    # Clone the `rust-g` repository to a directory of your choice
     git clone https://github.com/tgstation/rust-g.git
     # in the `rust-g` directory...
     cd rust-g

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The [Rust] compiler:
 1. Set the default compiler to **32-bit**:
 
     ```sh
+    # Clone the `rust-g` to a directory of your choise
+    git clone https://github.com/tgstation/rust-g.git
     # in the `rust-g` directory...
     cd rust-g
     # Linux


### PR DESCRIPTION
Make it more clear to understand what "rust-g" folder the instructions are referring to by adding the instruction to clone the repository.
