### PR TITLE
Clamp noise gen output to [0,1]

### DIFF
--- a/src/noise_gen.rs
+++ b/src/noise_gen.rs
@@ -30,16 +30,8 @@ fn get_at_coordinates(seed_as_str: &str, x_as_str: &str, y_as_str: &str) -> Resu
         };
         //perlin noise produces a result in [-sqrt(0.5), sqrt(0.5)] which we scale to [0, 1] for simplicity
         let unscaled = generator.get([x, y]);
-        let scaled_from_0_to_1 = (unscaled * 2.0_f64.sqrt() + 1.0) / 2.0;
-        let clamped = if scaled_from_0_to_1 < 0.0 {
-            0.0
-        }
-        else if scaled_from_0_to_1 > 1.0 {
-            1.0
-        }
-        else {
-            scaled_from_0_to_1
-        };
+        let scaled = (unscaled * 2.0_f64.sqrt() + 1.0) / 2.0;
+        let clamped = scaled.min(1.0).max(0.0);
         Ok(clamped.to_string())
     })
 }

--- a/src/noise_gen.rs
+++ b/src/noise_gen.rs
@@ -31,6 +31,15 @@ fn get_at_coordinates(seed_as_str: &str, x_as_str: &str, y_as_str: &str) -> Resu
         //perlin noise produces a result in [-sqrt(0.5), sqrt(0.5)] which we scale to [0, 1] for simplicity
         let unscaled = generator.get([x, y]);
         let scaled_from_0_to_1 = (unscaled * 2.0_f64.sqrt() + 1.0) / 2.0;
-        Ok(scaled_from_0_to_1.to_string())
+        let clamped = if scaled_from_0_to_1 < 0.0 {
+            0.0
+        }
+        else if scaled_from_0_to_1 > 1.0 {
+            1.0
+        }
+        else {
+            scaled_from_0_to_1
+        };
+        Ok(clamped.to_string())
     })
 }


### PR DESCRIPTION
rounding errors occasionally caused a result slightly above or below the acceptable range.