### PR TITLE
Add noise to the default features of rust-g

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = { version = "1.3", optional = true }
 mysql = { version = "18.2", optional = true }
 
 [features]
-default = ["dmi", "log", "git", "http", "sql"]
+default = ["dmi", "log", "git", "http", "sql", "noise"]
 dmi = ["png"]
 file = []
 hash = ["crypto-hash", "hex"]


### PR DESCRIPTION
Noise will be used in https://github.com/tgstation/tgstation/pull/51082 so I'm adding it to the default features. :)