### PR TITLE
Make code more idiomatic to standard Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "rust-g"
+edition = "2018"
 version = "0.4.5"
 authors = ["Bjorn Neergaard <bjorn@neersighted.com>"]
 repository = "https://github.com/tgstation/rust-g"

--- a/build.rs
+++ b/build.rs
@@ -2,12 +2,6 @@
 
 use std::{fs::File, io::Write};
 
-macro_rules! enabled {
-    ($name:expr) => {
-        std::env::var(concat!("CARGO_FEATURE_", $name)).is_ok()
-    };
-}
-
 fn main() {
     let mut f = File::create("target/rust_g.dm").unwrap();
 
@@ -62,7 +56,7 @@ fn main() {
     .unwrap();
 
     // module: dmi
-    if enabled!("DMI") {
+    if cfg!(feature = "DMI") {
         write!(f, r#"
 #define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
 #define rustg_dmi_create_png(path, width, height, data) call(RUST_G, "dmi_create_png")(path, width, height, data)
@@ -70,14 +64,14 @@ fn main() {
     }
 
     // module: noise
-    if enabled!("NOISE") {
+    if cfg!(feature = "NOISE") {
         write!(f, r#"
 #define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)
 "#).unwrap()
     }
 
     // module: file
-    if enabled!("FILE") {
+    if cfg!(feature = "FILE") {
         write!(
             f,
             r#"
@@ -95,7 +89,7 @@ fn main() {
     }
 
     // module: git
-    if enabled!("GIT") {
+    if cfg!(feature = "GIT") {
         write!(
             f,
             r#"
@@ -107,7 +101,7 @@ fn main() {
     }
 
     // module: hash
-    if enabled!("HASH") {
+    if cfg!(feature = "HASH") {
         write!(f, r#"
 #define rustg_hash_string(algorithm, text) call(RUST_G, "hash_string")(algorithm, text)
 #define rustg_hash_file(algorithm, fname) call(RUST_G, "hash_file")(algorithm, fname)
@@ -124,7 +118,7 @@ fn main() {
     }
 
     // module: log
-    if enabled!("LOG") {
+    if cfg!(feature = "LOG") {
         write!(
             f,
             r#"
@@ -136,7 +130,7 @@ fn main() {
     }
 
     // module: url
-    if enabled!("URL") {
+    if cfg!(feature = "URL") {
         write!(
             f,
             r#"
@@ -153,7 +147,7 @@ fn main() {
     }
 
     // module: http
-    if enabled!("HTTP") {
+    if cfg!(feature = "HTTP") {
         write!(f, r#"
 #define RUSTG_HTTP_METHOD_GET "get"
 #define RUSTG_HTTP_METHOD_PUT "put"
@@ -168,7 +162,7 @@ fn main() {
     }
 
     // module: sql
-    if enabled!("SQL") {
+    if cfg!(feature = "SQL") {
         write!(f, r#"
 #define rustg_sql_connect_pool(options) call(RUST_G, "sql_connect_pool")(options)
 #define rustg_sql_query_async(handle, query, params) call(RUST_G, "sql_query_async")(handle, query, params)

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,12 @@
 
 use std::{fs::File, io::Write};
 
+macro_rules! enabled {
+    ($name:expr) => {
+        std::env::var(concat!("CARGO_FEATURE_", $name)).is_ok()
+    };
+}
+
 fn main() {
     let mut f = File::create("target/rust_g.dm").unwrap();
 
@@ -56,7 +62,7 @@ fn main() {
     .unwrap();
 
     // module: dmi
-    if cfg!(feature = "DMI") {
+    if enabled!("DMI") {
         write!(f, r#"
 #define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
 #define rustg_dmi_create_png(path, width, height, data) call(RUST_G, "dmi_create_png")(path, width, height, data)
@@ -64,14 +70,14 @@ fn main() {
     }
 
     // module: noise
-    if cfg!(feature = "NOISE") {
+    if enabled!("NOISE") {
         write!(f, r#"
 #define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)
 "#).unwrap()
     }
 
     // module: file
-    if cfg!(feature = "FILE") {
+    if enabled!("FILE") {
         write!(
             f,
             r#"
@@ -89,7 +95,7 @@ fn main() {
     }
 
     // module: git
-    if cfg!(feature = "GIT") {
+    if enabled!("GIT") {
         write!(
             f,
             r#"
@@ -101,7 +107,7 @@ fn main() {
     }
 
     // module: hash
-    if cfg!(feature = "HASH") {
+    if enabled!("HASH") {
         write!(f, r#"
 #define rustg_hash_string(algorithm, text) call(RUST_G, "hash_string")(algorithm, text)
 #define rustg_hash_file(algorithm, fname) call(RUST_G, "hash_file")(algorithm, fname)
@@ -118,7 +124,7 @@ fn main() {
     }
 
     // module: log
-    if cfg!(feature = "LOG") {
+    if enabled!("LOG") {
         write!(
             f,
             r#"
@@ -130,7 +136,7 @@ fn main() {
     }
 
     // module: url
-    if cfg!(feature = "URL") {
+    if enabled!("URL") {
         write!(
             f,
             r#"
@@ -147,7 +153,7 @@ fn main() {
     }
 
     // module: http
-    if cfg!(feature = "HTTP") {
+    if enabled!("HTTP") {
         write!(f, r#"
 #define RUSTG_HTTP_METHOD_GET "get"
 #define RUSTG_HTTP_METHOD_PUT "put"
@@ -162,7 +168,7 @@ fn main() {
     }
 
     // module: sql
-    if cfg!(feature = "SQL") {
+    if enabled!("SQL") {
         write!(f, r#"
 #define rustg_sql_connect_pool(options) call(RUST_G, "sql_connect_pool")(options)
 #define rustg_sql_query_async(handle, query, params) call(RUST_G, "sql_query_async")(handle, query, params)

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,6 @@
 //! Buildscript which will save a `rust_g.dm` with the DLL's public API.
 
-use std::fs::File;
-use std::io::Write;
+use std::{fs::File, io::Write};
 
 macro_rules! enabled {
     ($name:expr) => {

--- a/build.rs
+++ b/build.rs
@@ -1,19 +1,21 @@
 //! Buildscript which will save a `rust_g.dm` with the DLL's public API.
 
-use std::io::Write;
 use std::fs::File;
+use std::io::Write;
 
 macro_rules! enabled {
     ($name:expr) => {
         std::env::var(concat!("CARGO_FEATURE_", $name)).is_ok()
-    }
+    };
 }
 
 fn main() {
     let mut f = File::create("target/rust_g.dm").unwrap();
 
     // header
-    write!(f, r#"// rust_g.dm - DM API for rust_g extension library
+    write!(
+        f,
+        r#"// rust_g.dm - DM API for rust_g extension library
 //
 // To configure, create a `rust_g.config.dm` and set what you care about from
 // the following options:
@@ -56,7 +58,9 @@ fn main() {
 #define RUSTG_JOB_NO_RESULTS_YET "NO RESULTS YET"
 #define RUSTG_JOB_NO_SUCH_JOB "NO SUCH JOB"
 #define RUSTG_JOB_ERROR "JOB PANICKED"
-"#).unwrap();
+"#
+    )
+    .unwrap();
 
     // module: dmi
     if enabled!("DMI") {
@@ -75,7 +79,9 @@ fn main() {
 
     // module: file
     if enabled!("FILE") {
-        write!(f, r#"
+        write!(
+            f,
+            r#"
 #define rustg_file_read(fname) call(RUST_G, "file_read")(fname)
 #define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, fname)
 #define rustg_file_append(text, fname) call(RUST_G, "file_append")(text, fname)
@@ -84,15 +90,21 @@ fn main() {
 #define file2text(fname) rustg_file_read(fname)
 #define text2file(text, fname) rustg_file_append(text, fname)
 #endif
-"#).unwrap();
+"#
+        )
+        .unwrap();
     }
 
     // module: git
     if enabled!("GIT") {
-        write!(f, r#"
+        write!(
+            f,
+            r#"
 #define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)
 #define rustg_git_commit_date(rev) call(RUST_G, "rg_git_commit_date")(rev)
-"#).unwrap();
+"#
+        )
+        .unwrap();
     }
 
     // module: hash
@@ -114,15 +126,21 @@ fn main() {
 
     // module: log
     if enabled!("LOG") {
-        write!(f, r#"
+        write!(
+            f,
+            r#"
 #define rustg_log_write(fname, text, format) call(RUST_G, "log_write")(fname, text, format)
 /proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
-"#).unwrap();
+"#
+        )
+        .unwrap();
     }
 
     // module: url
     if enabled!("URL") {
-        write!(f, r#"
+        write!(
+            f,
+            r#"
 #define rustg_url_encode(text) call(RUST_G, "url_encode")(text)
 #define rustg_url_decode(text) call(RUST_G, "url_decode")(text)
 
@@ -130,7 +148,9 @@ fn main() {
 #define url_encode(text) rustg_url_encode(text)
 #define url_decode(text) rustg_url_decode(text)
 #endif
-"#).unwrap();
+"#
+        )
+        .unwrap();
     }
 
     // module: http

--- a/src/byond.rs
+++ b/src/byond.rs
@@ -1,9 +1,10 @@
-use std::borrow::Cow;
-use std::cell::RefCell;
-use std::ffi::{CStr, CString};
-use std::slice;
-
-use std::os::raw::{c_char, c_int};
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    ffi::{CStr, CString},
+    os::raw::{c_char, c_int},
+    slice,
+};
 
 static EMPTY_STRING: c_char = 0;
 thread_local! {

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -1,7 +1,9 @@
 use crate::error::{Error, Result};
 use png::{Decoder, Encoder, HasParameters, OutputInfo};
-use std::fs::{create_dir_all, File};
-use std::path::Path;
+use std::{
+    fs::{create_dir_all, File},
+    path::Path,
+};
 
 byond_fn! { dmi_strip_metadata(path) {
     strip_metadata(path).err()

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -1,8 +1,7 @@
+use crate::error::{Error, Result};
 use png::{Decoder, Encoder, HasParameters, OutputInfo};
 use std::fs::{create_dir_all, File};
 use std::path::Path;
-
-use error::{Error, Result};
 
 byond_fn! { dmi_strip_metadata(path) {
     strip_metadata(path).err()

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -1,8 +1,8 @@
-use std::fs::{File, create_dir_all};
-use std::path::Path;
 use png::{Decoder, Encoder, HasParameters, OutputInfo};
+use std::fs::{create_dir_all, File};
+use std::path::Path;
 
-use error::{Result, Error};
+use error::{Error, Result};
 
 byond_fn! { dmi_strip_metadata(path) {
     strip_metadata(path).err()

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
 use std::io;
+use std::num::{ParseFloatError, ParseIntError};
 use std::result;
 use std::str::Utf8Error;
-use std::num::{ParseIntError, ParseFloatError};
 
-#[cfg(feature="png")]
+#[cfg(feature = "png")]
 use png::{DecodingError, EncodingError};
 
 pub type Result<T> = result::Result<T, Error>;
@@ -20,23 +20,23 @@ pub enum Error {
     Io(#[cause] io::Error),
     #[fail(display = "Invalid algorithm specified.")]
     InvalidAlgorithm,
-    #[cfg(feature="png")]
+    #[cfg(feature = "png")]
     #[fail(display = "{}", _0)]
     ImageDecoding(#[cause] DecodingError),
-    #[cfg(feature="png")]
+    #[cfg(feature = "png")]
     #[fail(display = "{}", _0)]
     ImageEncoding(#[cause] EncodingError),
     #[fail(display = "{}", _0)]
     ParseIntError(#[cause] ParseIntError),
     #[fail(display = "{}", _0)]
     ParseFloatError(#[cause] ParseFloatError),
-    #[cfg(feature="png")]
+    #[cfg(feature = "png")]
     #[fail(display = "Invalid png data.")]
     InvalidPngDataError,
-    #[cfg(feature="http")]
+    #[cfg(feature = "http")]
     #[fail(display = "{}", _0)]
     RequestError(#[cause] reqwest::Error),
-    #[cfg(feature="http")]
+    #[cfg(feature = "http")]
     #[fail(display = "{}", _0)]
     SerializationError(#[cause] serde_json::Error),
 }
@@ -53,14 +53,14 @@ impl From<Utf8Error> for Error {
     }
 }
 
-#[cfg(feature="png")]
+#[cfg(feature = "png")]
 impl From<DecodingError> for Error {
     fn from(error: DecodingError) -> Error {
         Error::ImageDecoding(error)
     }
 }
 
-#[cfg(feature="png")]
+#[cfg(feature = "png")]
 impl From<EncodingError> for Error {
     fn from(error: EncodingError) -> Error {
         Error::ImageEncoding(error)
@@ -78,14 +78,14 @@ impl From<ParseFloatError> for Error {
         Error::ParseFloatError(error)
     }
 }
-#[cfg(feature="http")]
+#[cfg(feature = "http")]
 impl From<reqwest::Error> for Error {
     fn from(error: reqwest::Error) -> Error {
         Error::RequestError(error)
     }
 }
 
-#[cfg(feature="http")]
+#[cfg(feature = "http")]
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Error {
         Error::SerializationError(error)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,9 @@
-use std::io;
-use std::num::{ParseFloatError, ParseIntError};
-use std::result;
-use std::str::Utf8Error;
+use std::{
+    io,
+    num::{ParseFloatError, ParseIntError},
+    result,
+    str::Utf8Error,
+};
 
 #[cfg(feature = "png")]
 use png::{DecodingError, EncodingError};

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,8 +1,8 @@
-use std::fs::File;
-use std::fs::OpenOptions;
-use std::io::{Read, Write};
-
-use error::Result;
+use crate::error::Result;
+use std::{
+    fs::{File, OpenOptions},
+    io::{Read, Write},
+};
 
 byond_fn! { file_read(path) {
     read(path).ok()

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,5 @@
-use git2::{Repository, Error, ErrorCode};
-use chrono::{Utc, TimeZone};
+use chrono::{TimeZone, Utc};
+use git2::{Error, ErrorCode, Repository};
 
 thread_local! {
     static REPOSITORY: Result<Repository, Error> = Repository::open(".");

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,11 +1,6 @@
-use std::fs::File;
-use std::io;
-
-use crypto_hash;
+use crate::error::{Error, Result};
 use crypto_hash::{Algorithm, Hasher};
-use hex;
-
-use error::{Error, Result};
+use std::{fs::File, io};
 
 byond_fn! { hash_string(algorithm, string) {
     string_hash(algorithm, string).ok()

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,4 @@
-use std::collections::hash_map::{ HashMap };
+use std::collections::hash_map::HashMap;
 use std::collections::BTreeMap;
 
 use error::Result;
@@ -62,15 +62,18 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 
 fn setup_http_client() -> reqwest::Client {
-    use reqwest::{ Client, header::{ HeaderMap, USER_AGENT } };
+    use reqwest::{
+        header::{HeaderMap, USER_AGENT},
+        Client,
+    };
 
     let mut headers = HeaderMap::new();
-    headers.insert(USER_AGENT, format!("{}/{}", PKG_NAME, VERSION).parse().unwrap());
+    headers.insert(
+        USER_AGENT,
+        format!("{}/{}", PKG_NAME, VERSION).parse().unwrap(),
+    );
 
-    Client::builder()
-        .default_headers(headers)
-        .build()
-        .unwrap()
+    Client::builder().default_headers(headers).build().unwrap()
 }
 
 lazy_static! {
@@ -85,7 +88,13 @@ struct RequestPrep {
     output_filename: Option<String>,
 }
 
-fn construct_request(method: &str, url: &str, body: &str, headers: &str, options: Option<&str>) -> Result<RequestPrep> {
+fn construct_request(
+    method: &str,
+    url: &str,
+    body: &str,
+    headers: &str,
+    options: Option<&str>,
+) -> Result<RequestPrep> {
     let mut req = match method {
         "post" => HTTP_CLIENT.post(url),
         "put" => HTTP_CLIENT.put(url),
@@ -115,7 +124,10 @@ fn construct_request(method: &str, url: &str, body: &str, headers: &str, options
         }
     }
 
-    Ok(RequestPrep { req, output_filename })
+    Ok(RequestPrep {
+        req,
+        output_filename,
+    })
 }
 
 fn submit_request(prep: RequestPrep) -> Result<String> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,7 +1,5 @@
-use crate::error::Result;
-use crate::jobs;
-use std::collections::hash_map::HashMap;
-use std::collections::BTreeMap;
+use crate::{error::Result, jobs};
+use std::collections::{BTreeMap, HashMap};
 
 // ----------------------------------------------------------------------------
 // Interface

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,8 +1,7 @@
+use crate::error::Result;
+use crate::jobs;
 use std::collections::hash_map::HashMap;
 use std::collections::BTreeMap;
-
-use error::Result;
-use jobs;
 
 // ----------------------------------------------------------------------------
 // Interface

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -1,8 +1,8 @@
 //! Job system
+use std::cell::RefCell;
+use std::collections::hash_map::{Entry, HashMap};
 use std::sync::mpsc;
 use std::thread;
-use std::collections::hash_map::{HashMap, Entry};
-use std::cell::RefCell;
 
 struct Job {
     rx: mpsc::Receiver<Output>,

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -1,8 +1,10 @@
 //! Job system
-use std::cell::RefCell;
-use std::collections::hash_map::{Entry, HashMap};
-use std::sync::mpsc;
-use std::thread;
+use std::{
+    cell::RefCell,
+    collections::hash_map::{Entry, HashMap},
+    sync::mpsc,
+    thread,
+};
 
 struct Job {
     rx: mpsc::Receiver<Output>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,31 +1,31 @@
 #[macro_use]
 extern crate failure;
 
-#[cfg(feature="chrono")]
+#[cfg(feature = "chrono")]
 extern crate chrono;
-#[cfg(feature="crypto-hash")]
+#[cfg(feature = "crypto-hash")]
 extern crate crypto_hash;
-#[cfg(feature="git2")]
+#[cfg(feature = "git2")]
 extern crate git2;
-#[cfg(feature="hex")]
+#[cfg(feature = "hex")]
 extern crate hex;
-#[cfg(feature="percent-encoding")]
-extern crate percent_encoding;
-#[cfg(feature="png")]
-extern crate png;
-#[cfg(feature="noise")]
+#[cfg(feature = "noise")]
 extern crate noise;
-#[cfg(feature="http")]
+#[cfg(feature = "percent-encoding")]
+extern crate percent_encoding;
+#[cfg(feature = "png")]
+extern crate png;
+#[cfg(feature = "http")]
 extern crate reqwest;
-#[cfg(any(feature="http", feature="sql"))]
+#[cfg(any(feature = "http", feature = "sql"))]
 #[macro_use]
 extern crate serde_derive;
-#[cfg(any(feature="http", feature="sql"))]
+#[cfg(any(feature = "http", feature = "sql"))]
 extern crate serde_json;
-#[cfg(any(feature="http", feature="sql"))]
+#[cfg(any(feature = "http", feature = "sql"))]
 #[macro_use]
 extern crate lazy_static;
-#[cfg(feature="sql")]
+#[cfg(feature = "sql")]
 extern crate mysql;
 
 #[macro_use]
@@ -34,24 +34,24 @@ mod byond;
 mod error;
 mod jobs;
 
-#[cfg(feature="dmi")]
+#[cfg(feature = "dmi")]
 pub mod dmi;
-#[cfg(feature="file")]
+#[cfg(feature = "file")]
 pub mod file;
-#[cfg(feature="git")]
+#[cfg(feature = "git")]
 pub mod git;
-#[cfg(feature="hash")]
+#[cfg(feature = "hash")]
 pub mod hash;
-#[cfg(feature="log")]
-pub mod log;
-#[cfg(feature="url")]
-pub mod url;
-#[cfg(feature="noise")]
-pub mod noise_gen;
-#[cfg(feature="http")]
+#[cfg(feature = "http")]
 pub mod http;
-#[cfg(feature="sql")]
+#[cfg(feature = "log")]
+pub mod log;
+#[cfg(feature = "noise")]
+pub mod noise_gen;
+#[cfg(feature = "sql")]
 pub mod sql;
+#[cfg(feature = "url")]
+pub mod url;
 
-#[cfg(not(target_pointer_width="32"))]
-const _: () = "rust-g must be compiled for a 32-bit target";
+#[cfg(not(target_pointer_width = "32"))]
+compile_error!("rust-g must be compiled for a 32-bit target");

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,3 +1,4 @@
+use crate::error::{Error, Result};
 use std::cell::RefCell;
 use std::collections::hash_map::{Entry, HashMap};
 use std::ffi::OsString;
@@ -7,8 +8,6 @@ use std::io::Write;
 use std::path::Path;
 
 use chrono::Utc;
-
-use error::{Error, Result};
 
 thread_local! {
     static FILE_MAP: RefCell<HashMap<OsString, File>> = RefCell::new(HashMap::new());

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,13 +1,14 @@
 use crate::error::{Error, Result};
-use std::cell::RefCell;
-use std::collections::hash_map::{Entry, HashMap};
-use std::ffi::OsString;
-use std::fs;
-use std::fs::{File, OpenOptions};
-use std::io::Write;
-use std::path::Path;
-
 use chrono::Utc;
+use std::{
+    cell::RefCell,
+    collections::hash_map::{Entry, HashMap},
+    ffi::OsString,
+    fs,
+    fs::{File, OpenOptions},
+    io::Write,
+    path::Path,
+};
 
 thread_local! {
     static FILE_MAP: RefCell<HashMap<OsString, File>> = RefCell::new(HashMap::new());

--- a/src/noise_gen.rs
+++ b/src/noise_gen.rs
@@ -1,7 +1,8 @@
 use noise::{NoiseFn, Perlin, Seedable};
-use std::cell::RefCell;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::{
+    cell::RefCell,
+    collections::hash_map::{Entry, HashMap},
+};
 
 use crate::error::Result;
 

--- a/src/noise_gen.rs
+++ b/src/noise_gen.rs
@@ -1,7 +1,7 @@
 use noise::{NoiseFn, Perlin, Seedable};
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 
 use crate::error::Result;
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1,3 +1,5 @@
+use crate::jobs;
+
 use std::collections::HashMap;
 use std::error::Error;
 use std::sync::RwLock;
@@ -10,8 +12,6 @@ use mysql::consts::ColumnFlags;
 use mysql::consts::ColumnType::*;
 use mysql::prelude::Queryable;
 use mysql::{OptsBuilder, Params, Pool};
-
-use jobs;
 
 // ----------------------------------------------------------------------------
 // Interface

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1,17 +1,11 @@
 use crate::jobs;
-
-use std::collections::HashMap;
-use std::error::Error;
-use std::sync::RwLock;
-use std::time::Duration;
-
-use serde_json::map::Map;
-use serde_json::{json, Number};
-
-use mysql::consts::ColumnFlags;
-use mysql::consts::ColumnType::*;
-use mysql::prelude::Queryable;
-use mysql::{OptsBuilder, Params, Pool};
+use mysql::{
+    consts::{ColumnFlags, ColumnType::*},
+    prelude::Queryable,
+    OptsBuilder, Params, Pool,
+};
+use serde_json::{json, map::Map, Number};
+use std::{collections::HashMap, error::Error, sync::RwLock, time::Duration};
 
 // ----------------------------------------------------------------------------
 // Interface

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1,14 +1,14 @@
+use std::collections::HashMap;
 use std::error::Error;
 use std::sync::RwLock;
 use std::time::Duration;
-use std::collections::HashMap;
 
 use serde_json::map::Map;
 use serde_json::{json, Number};
 
-use mysql::prelude::Queryable;
 use mysql::consts::ColumnFlags;
 use mysql::consts::ColumnType::*;
+use mysql::prelude::Queryable;
 use mysql::{OptsBuilder, Params, Pool};
 
 use jobs;
@@ -127,9 +127,12 @@ fn sql_connect(options: ConnectOptions) -> Result<serde_json::Value, Box<dyn Err
     let pool = Pool::new_manual(
         options.min_threads.unwrap_or(DEFAULT_MIN_THREADS),
         options.max_threads.unwrap_or(DEFAULT_MAX_THREADS),
-        builder)?;
+        builder,
+    )?;
 
-    let handle = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed).to_string();
+    let handle = NEXT_ID
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        .to_string();
     let mut poolguard = POOL.write()?;
     poolguard.insert(handle.clone(), pool);
     Ok(json!({
@@ -165,7 +168,9 @@ fn do_query(handle: &str, query: &str, params: &str) -> Result<serde_json::Value
         let mut json_row: Vec<serde_json::Value> = Vec::new();
         for (i, col) in row.columns_ref().iter().enumerate() {
             let ctype = col.column_type();
-            let value = row.as_ref(i).ok_or("length of row was smaller than column count")?;
+            let value = row
+                .as_ref(i)
+                .ok_or("length of row was smaller than column count")?;
             let converted = match value {
                 mysql::Value::Bytes(b) => match ctype {
                     MYSQL_TYPE_VARCHAR | MYSQL_TYPE_STRING | MYSQL_TYPE_VAR_STRING => {
@@ -187,9 +192,9 @@ fn do_query(handle: &str, query: &str, params: &str) -> Result<serde_json::Value
                     }
                     _ => serde_json::Value::Null,
                 },
-                mysql::Value::Float(f) => {
-                    serde_json::Value::Number(Number::from_f64(f64::from(*f)).unwrap_or_else(|| Number::from(0)))
-                }
+                mysql::Value::Float(f) => serde_json::Value::Number(
+                    Number::from_f64(f64::from(*f)).unwrap_or_else(|| Number::from(0)),
+                ),
                 mysql::Value::Int(i) => serde_json::Value::Number(Number::from(*i)),
                 mysql::Value::UInt(u) => serde_json::Value::Number(Number::from(*u)),
                 mysql::Value::Date(year, month, day, hour, minute, second, _ms) => {
@@ -236,7 +241,7 @@ fn json_to_mysql(val: serde_json::Value) -> mysql::Value {
             } else if let Some(v) = i.as_i64() {
                 mysql::Value::Int(v)
             } else if let Some(v) = i.as_f64() {
-                mysql::Value::Float(v as f32)  // Loses precision.
+                mysql::Value::Float(v as f32) // Loses precision.
             } else {
                 mysql::Value::NULL
             }

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,6 +1,5 @@
+use crate::error::{Error, Result};
 use percent_encoding::{percent_decode, utf8_percent_encode, PATH_SEGMENT_ENCODE_SET};
-
-use error::{Error, Result};
 
 byond_fn! { url_encode(data) {
     Some(encode(data))

--- a/tests/dm-tests.rs
+++ b/tests/dm-tests.rs
@@ -1,6 +1,6 @@
 use std::process::{Command, Output};
 
-#[cfg(feature="git")]
+#[cfg(feature = "git")]
 #[test]
 fn git() {
     run_dm_tests("git");
@@ -17,9 +17,21 @@ fn run_dm_tests(name: &str) {
     let dme = format!("tests/dm/{}.dme", name);
     let dmb = format!("tests/dm/{}.dmb", name);
 
-    let target_dir = if cfg!(target_os="linux") { "i686-unknown-linux-gnu" } else { "i686-pc-windows-gnu" };
-    let profile = if cfg!(debug_assertions) { "debug" } else { "release" };
-    let fname = if cfg!(target_os="linux") { "librust_g.so" } else { "rust_g.dll "};
+    let target_dir = if cfg!(target_os = "linux") {
+        "i686-unknown-linux-gnu"
+    } else {
+        "i686-pc-windows-gnu"
+    };
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    let fname = if cfg!(target_os = "linux") {
+        "librust_g.so"
+    } else {
+        "rust_g.dll "
+    };
     let rust_g = format!("target/{}/{}/{}", target_dir, profile, fname);
 
     let output = Command::new("bash")
@@ -36,7 +48,8 @@ fn run_dm_tests(name: &str) {
         .arg(&dream_daemon)
         .arg(&dmb)
         .arg("-trusted")
-        .arg("-cd").arg(env!("CARGO_MANIFEST_DIR"))
+        .arg("-cd")
+        .arg(env!("CARGO_MANIFEST_DIR"))
         .env("RUST_G", &rust_g)
         .output()
         .unwrap();


### PR DESCRIPTION
I do Rust as part of my living, and I wanted to update this codebase to match with the standard way Rust repositories are managed. This PR is mostly running Rustfmt and fixing Clippy errors. These are both invaluable tools I highly recommend you try out if you haven't already. Rustfmt is an autoformatter that not only makes it so there's no conflicting styles, but also makes it really easy to do big refactors without having to care about style too much. VS Code has an option to run a formatter when you save, and if you're using a Rust LSP (RLS or the newer rust-analyzer), then it helps productivity a lot. Clippy is a very good linter that finds issues that the normal rustc doesn't catch. For this repo, it found some style issues and a minor performance issue that were easily fixed up.

A lot of the code is inside macros, which clippy and Rustfmt can't introspect very well, but this covers most of it.

- Runs cargo fmt*
- Fixes error brought up by cargo clippy*
- Upgrades to Rust 2018, which is regularly updated
- Change `const _: () = "bla"` to `compile_error!("bla")`
- Change `use` to be use the idiomatic grouped syntax

\* - I highly recommend setting up a GitHub action to do these.