### PR TITLE
Match expectations when overriding the built-in procs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -86,8 +86,8 @@ fn main() {
 #define rustg_file_append(text, fname) call(RUST_G, "file_append")(text, fname)
 
 #ifdef RUSTG_OVERRIDE_BUILTINS
-#define file2text(fname) rustg_file_read(fname)
-#define text2file(text, fname) rustg_file_append(text, fname)
+#define file2text(fname) rustg_file_read("[fname]")
+#define text2file(text, fname) rustg_file_append(text, "[fname]")
 #endif
 "#
         )


### PR DESCRIPTION
Updates the defines for `fil2text` and `text2file` to automatically stringify `fname`. This makes these overrides sensible since the built-in version can take either a `file()` object or string.