### PR TITLE
Sets the debug and test linux build to use all features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,8 @@ jobs:
           toolchain: stable
           command: check
           args: --target i686-pc-windows-msvc --all-features
-      - uses: actions-rs/cargo@v1
+      - name: Build (release) (default features)
+        uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: build
@@ -53,21 +54,21 @@ jobs:
           toolchain: stable
           command: check
           args: --target i686-unknown-linux-gnu --all-features
-      - name: Build (Debug)
+      - name: Build (Debug) (all features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: build
-          args: --target i686-unknown-linux-gnu
-      - name: Run tests
+          args: --target i686-unknown-linux-gnu --all-features
+      - name: Run tests (all features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: test
-          args: --target i686-unknown-linux-gnu
+          args: --target i686-unknown-linux-gnu --all-features
         env:
           BYOND_BIN: /home/runner/BYOND/byond/bin
-      - name: Build (release)
+      - name: Build (release) (default features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable


### PR DESCRIPTION
**Problem:** PRs and all features aren't properly running created unit tests.
Nor are they actually being fully compiled (only checked) on Linux.

**Solution:** Only have the release builds that are distributed as artifacts run with the default features.
This way, tests can cover all features.