### PR TITLE
Make the url feature default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rand = {version = "0.8", optional = true}
 
 
 [features]
-default = ["cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql"]
+default = ["cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "url"]
 
 # default features
 cellularnoise = ["rand"]
@@ -55,10 +55,10 @@ http = ["reqwest", "serde", "serde_json", "once_cell", "jobs"]
 json = ["serde", "serde_json"]
 log = ["chrono"]
 sql = ["mysql", "serde", "serde_json", "once_cell", "dashmap", "jobs"]
+url = ["url-dep", "percent-encoding"]
 
 # non-default features
 hash = ["base64", "const-random", "md-5", "hex", "sha-1", "sha2",  "twox-hash"]
-url = ["url-dep", "percent-encoding"]
 unzip = ["zip", "jobs"]
 
 # internal feature-like things


### PR DESCRIPTION
We're using this on tg right now with https://github.com/tgstation/tgstation/pull/60190, and it appears to be much faster and has not yet caused issues.

SpaceManiac has brought it up, and I've agreed for a long time, that having all these individual features was a mistake--I'd eventually like to get rid of them once they're all on by default.