### PR TITLE
Stringify url_encode and decode input before sending it to Rust

### DIFF
--- a/dmsrc/url.dm
+++ b/dmsrc/url.dm
@@ -1,5 +1,5 @@
-#define rustg_url_encode(text) call(RUST_G, "url_encode")(text)
-#define rustg_url_decode(text) call(RUST_G, "url_decode")(text)
+#define rustg_url_encode(text) call(RUST_G, "url_encode")("[text]")
+#define rustg_url_decode(text) call(RUST_G, "url_decode")("[text]")
 
 #ifdef RUSTG_OVERRIDE_BUILTINS
 	#define url_encode(text) rustg_url_encode(text)

--- a/dmsrc/url.dm
+++ b/dmsrc/url.dm
@@ -1,5 +1,5 @@
 #define rustg_url_encode(text) call(RUST_G, "url_encode")("[text]")
-#define rustg_url_decode(text) call(RUST_G, "url_decode")("[text]")
+#define rustg_url_decode(text) call(RUST_G, "url_decode")(text)
 
 #ifdef RUSTG_OVERRIDE_BUILTINS
 	#define url_encode(text) rustg_url_encode(text)


### PR DESCRIPTION
Try to stringify all input before sending it to Rust since interop only works with strings
Should be good enough to only stringify inside the rustg_url_encode/decode define since the other defines just refer to that
PR on request of @Mothblocks from https://github.com/tgstation/tgstation/pull/60802