### PR TITLE
Add worley noise optional feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "dmsort"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4699f5cb7678f099b747ffdc1e6ce6cdc42579e29d28315aa715b9fd10324fc"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1508,7 @@ dependencies = [
  "chrono",
  "const-random",
  "dashmap",
+ "dmsort",
  "flume",
  "git2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ url = ["url-dep", "percent-encoding"]
 # non-default features
 hash = ["base64", "const-random", "md-5", "hex", "sha-1", "sha2",  "twox-hash"]
 unzip = ["zip", "jobs"]
+worleynoise = ["rand"]
 
 # internal feature-like things
 jobs = ["flume"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ mysql = { version = "20.0", optional = true }
 dashmap = { version = "4.0", optional = true }
 zip = { version = "0.5.8", optional = true }
 rand = {version = "0.8", optional = true}
-
+dmsort = {version = "1.0.0", optional = true}
 
 [features]
 default = ["cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "url"]
@@ -60,7 +60,7 @@ url = ["url-dep", "percent-encoding"]
 # non-default features
 hash = ["base64", "const-random", "md-5", "hex", "sha-1", "sha2",  "twox-hash"]
 unzip = ["zip", "jobs"]
-worleynoise = ["rand"]
+worleynoise = ["rand","dmsort"]
 
 # internal feature-like things
 jobs = ["flume"]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Additional features are:
 * hash: Faster replacement for `md5`, support for SHA-1, SHA-256, and SHA-512. Requires OpenSSL on Linux.
 * url: Faster replacements for `url_encode` and `url_decode`.
 * unzip: Function to download a .zip from a URL and unzip it to a directory.
+* worleynoise: Function that generates a type of nice looking cellular noise, more expensive than cellularnoise
 
 ## Installing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub mod sql;
 pub mod unzip;
 #[cfg(feature = "url")]
 pub mod url;
+#[cfg(feature = "worleynoise")]
+pub mod worleynoise;
 
 #[cfg(not(target_pointer_width = "32"))]
 compile_error!("rust-g must be compiled for a 32-bit target");

--- a/src/worleynoise.rs
+++ b/src/worleynoise.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use rand::*;
 use std::fmt::Write;
-use std::thread;
+use std::rc::Rc;
 
 byond_fn! { worley_generate(region_size, threshold, width, height) {
     worley_noise(region_size, threshold, width, height).ok()
@@ -27,9 +27,9 @@ fn worley_noise(str_reg_size : &str, str_positive_threshold: &str, str_width: &s
     for row in map.cell_map{
         for cell in row{
             if cell.value {
-                output.append_str("1");
+                let _ = write!(output, "1");
             } else {
-                output.append_str("0");
+                let _ = write!(output, "0");
             }
         }
     }

--- a/src/worleynoise.rs
+++ b/src/worleynoise.rs
@@ -12,10 +12,10 @@ fn worley_noise(    density_as_str: &str,
     width_as_str: &str,
     height_as_str: &str,
 ) -> Result<String> {
-    let density = density_as_str.parse::<f64>().unwrap(); // density of noise, 0 means no nodes and 100 means that every tile has a node.
-    let positive_threshold = positive_threshold_as_str.parse::<f64>().unwrap(); // threshold, if value in cell is above this it gets set to true, otherwise false.
-    let width = width_as_str.parse::<usize>().unwrap();
-    let height = height_as_str.parse::<usize>().unwrap();
+    let density = density_as_str.parse::<f64>()?; // density of noise, 0 means no nodes and 100 means that every tile has a node.
+    let positive_threshold = positive_threshold_as_str.parse::<f64>()?; // threshold, if value in cell is above this it gets set to true, otherwise false.
+    let width = width_as_str.parse::<usize>()?;
+    let height = height_as_str.parse::<usize>()?;
 
     let mut rng = rand::thread_rng();
 

--- a/src/worleynoise.rs
+++ b/src/worleynoise.rs
@@ -38,7 +38,7 @@ fn worley_noise(    density_as_str: &str,
     //we generate the actual noise by comparing the distance to the nearest node to the distance of the second nearest node and checking if it passes the threshold
     for row in 0..width as i32{
         for cell in 0..height as i32 {
-            dmsort::sort_by(&mut node_vec, |a,b| a.distance_to_sqrt(&cell,&row).partial_cmp( &b.distance_to_sqrt(&cell,&row)).unwrap());
+            dmsort::sort_by(&mut node_vec, |a,b| a.distance_to_sqrt(&cell,&row).partial_cmp( &b.distance_to_sqrt(&cell,&row))?);
             let comparative_distance = (node_vec[0].distance_to_sqrt(&cell,&row) - node_vec[1].distance_to_sqrt(&cell,&row)).abs();
             if comparative_distance > positive_threshold {
                 zplane[cell as usize][row as usize] = true;

--- a/src/worleynoise.rs
+++ b/src/worleynoise.rs
@@ -10,8 +10,13 @@ byond_fn! { worley_generate(region_size, threshold, node_per_region_chance, widt
 // This is a quite complex algorithm basically what it does is it creates 2 maps, one filled with cells and the other with 'regions' that map onto these cells.
 // Each region can spawn 1 node, the cell then determines wether it is true or false depending on the distance from it to the nearest node in the region minus the second closest node.
 // If this distance is greater than the threshold then the cell is true, otherwise it is false.
-fn worley_noise(str_reg_size : &str, str_positive_threshold: &str,str_node_per_region_chance : &str, str_width: &str, str_height: &str) -> Result<String>{
-
+fn worley_noise(
+    str_reg_size: &str,
+    str_positive_threshold: &str,
+    str_node_per_region_chance: &str,
+    str_width: &str,
+    str_height: &str,
+) -> Result<String> {
     let region_size = str_reg_size.parse::<i32>()?;
     let positive_threshold = str_positive_threshold.parse::<f32>()?;
     let width = str_width.parse::<i32>()?;
@@ -19,14 +24,14 @@ fn worley_noise(str_reg_size : &str, str_positive_threshold: &str,str_node_per_r
     let node_per_region_chance = str_node_per_region_chance.parse::<f32>()?;
 
     //i fucking mixed up width and height again. it really doesnt matter but here is a comment just warning you.
-    let mut map = Map::new(region_size,height,width,node_per_region_chance);
+    let mut map = Map::new(region_size, height, width, node_per_region_chance);
 
     map.generate_noise(positive_threshold as f32);
 
     let mut output = String::new();
 
-    for row in map.cell_map{
-        for cell in row{
+    for row in map.cell_map {
+        for cell in row {
             if cell.value {
                 let _ = write!(output, "1");
             } else {
@@ -37,39 +42,42 @@ fn worley_noise(str_reg_size : &str, str_positive_threshold: &str,str_node_per_r
     Ok(output)
 }
 
-
-struct Map{
-    region_size : i32,
-    region_map : Vec<Vec<Rc<Region>>>,
-    cell_map : Vec<Vec<Cell>>,
-    cell_map_width : i32,
-    cell_map_height : i32,
-    node_chance : f32
+struct Map {
+    region_size: i32,
+    region_map: Vec<Vec<Rc<Region>>>,
+    cell_map: Vec<Vec<Cell>>,
+    cell_map_width: i32,
+    cell_map_height: i32,
+    node_chance: f32,
 }
 
-impl Map{
-    fn new(region_size : i32,  cell_map_width : i32, cell_map_height : i32, node_chance : f32) -> Map{
-        let mut map = Map{
-            region_size : region_size,
-            region_map : Vec::new(),
-            cell_map : Vec::new(),
-            cell_map_width : cell_map_width,
-            cell_map_height : cell_map_height,
-            node_chance : node_chance
+impl Map {
+    fn new(region_size: i32, cell_map_width: i32, cell_map_height: i32, node_chance: f32) -> Map {
+        let mut map = Map {
+            region_size: region_size,
+            region_map: Vec::new(),
+            cell_map: Vec::new(),
+            cell_map_width: cell_map_width,
+            cell_map_height: cell_map_height,
+            node_chance: node_chance,
         };
 
         map.init_regions();
 
-        for x in 0..cell_map_width{
+        for x in 0..cell_map_width {
             map.cell_map.push(Vec::new());
-            for y in 0..cell_map_height{
-                let cell = Cell::new(x,y,map.region_map[(x / region_size) as usize][(y / region_size) as usize].clone());
-                        map.cell_map[(x) as usize].push(cell);
+            for y in 0..cell_map_height {
+                let cell = Cell::new(
+                    x,
+                    y,
+                    map.region_map[(x / region_size) as usize][(y / region_size) as usize].clone(),
+                );
+                map.cell_map[(x) as usize].push(cell);
             }
         }
         map
     }
-    fn init_regions(&mut self){
+    fn init_regions(&mut self) {
         let mut rng = rand::thread_rng();
 
         let regions_x = self.cell_map_width / self.region_size;
@@ -83,28 +91,29 @@ impl Map{
             self.region_map.push(Vec::new());
             for j in 0..regions_y {
                 distance_in_regions_since_last_node += 1;
-                let mut region =Region::new(i,j);
-                if rng.gen_range(0..100) as f32 <= self.node_chance || node_count < 2{
+                let mut region = Region::new(i, j);
+                if rng.gen_range(0..100) as f32 <= self.node_chance || node_count < 2 {
                     let xcord = rng.gen_range(0..self.region_size);
                     let ycord = rng.gen_range(0..self.region_size);
-                    let node = Node::new(xcord + i*self.region_size ,ycord + j*self.region_size );
+                    let node =
+                        Node::new(xcord + i * self.region_size, ycord + j * self.region_size);
                     region.node = Some(node);
-                    node_count+=1;
+                    node_count += 1;
                     distance_in_regions_since_last_node = 0;
                 }
 
-                if distance_in_regions_since_last_node > 3{
+                if distance_in_regions_since_last_node > 3 {
                     node_count = 0;
                 }
 
-                let  rcregion = Rc::new(region);
+                let rcregion = Rc::new(region);
 
                 self.region_map[i as usize].push(rcregion);
             }
         }
     }
 
-    fn get_regions_in_bound(&self, x : i32, y : i32, radius : i32) -> Vec<&Region>{
+    fn get_regions_in_bound(&self, x: i32, y: i32, radius: i32) -> Vec<&Region> {
         let mut regions = Vec::new();
         let x_min = x - radius;
         let x_max = x + radius;
@@ -112,10 +121,13 @@ impl Map{
         let y_max = y + radius;
         for i in x_min..x_max {
             for j in y_min..y_max {
-
                 let region_x = i;
                 let region_y = j;
-                if region_x >= 0 && region_x < self.region_map.len() as i32 && region_y >= 0 && region_y < self.region_map[region_x as usize].len() as i32 {
+                if region_x >= 0
+                    && region_x < self.region_map.len() as i32
+                    && region_y >= 0
+                    && region_y < self.region_map[region_x as usize].len() as i32
+                {
                     let region = &self.region_map[region_x as usize][region_y as usize];
                     regions.push(region.as_ref());
                 }
@@ -124,24 +136,29 @@ impl Map{
         regions
     }
 
-    fn generate_noise(&mut self,threshold : f32){
+    fn generate_noise(&mut self, threshold: f32) {
         for i in 0..self.cell_map.len() {
             for j in 0..self.cell_map[i as usize].len() {
-                let cell =  &self.cell_map[i as usize][j as usize];
-                let region = &self.region_map[cell.region.as_ref().reg_x as usize][cell.region.as_ref().reg_y as usize];
-                let neighbours = self.get_regions_in_bound(region.reg_x,region.reg_y,3);
-
+                let cell = &self.cell_map[i as usize][j as usize];
+                let region = &self.region_map[cell.region.as_ref().reg_x as usize]
+                    [cell.region.as_ref().reg_y as usize];
+                let neighbours = self.get_regions_in_bound(region.reg_x, region.reg_y, 3);
 
                 let mut node_vec = Vec::new();
                 for neighbour in neighbours {
-                    if neighbour.node.is_some(){
+                    if neighbour.node.is_some() {
                         let node = neighbour.node.as_ref().unwrap();
                         node_vec.push(node);
                     }
                 }
 
-                dmsort::sort_by(&mut node_vec, |a,b| quick_distance_from_to(cell.x, cell.y, a.x , a.y).partial_cmp(&quick_distance_from_to(cell.x, cell.y, b.x , b.y)).unwrap());
-                let dist = distance_from_to(cell.x, cell.y, node_vec[0].x , node_vec[0].y) - distance_from_to(cell.x, cell.y, node_vec[1].x , node_vec[1].y);
+                dmsort::sort_by(&mut node_vec, |a, b| {
+                    quick_distance_from_to(cell.x, cell.y, a.x, a.y)
+                        .partial_cmp(&quick_distance_from_to(cell.x, cell.y, b.x, b.y))
+                        .unwrap()
+                });
+                let dist = distance_from_to(cell.x, cell.y, node_vec[0].x, node_vec[0].y)
+                    - distance_from_to(cell.x, cell.y, node_vec[1].x, node_vec[1].y);
                 //
                 let mutable_cell = &mut self.cell_map[i as usize][j as usize];
                 if dist.abs() > threshold {
@@ -152,14 +169,14 @@ impl Map{
     }
 }
 
-fn distance_from_to(x1 : i32, y1 : i32, x2 : i32, y2 : i32) -> f32{
+fn distance_from_to(x1: i32, y1: i32, x2: i32, y2: i32) -> f32 {
     let x_diff = x1 - x2;
     let y_diff = y1 - y2;
     let distance = (((x_diff * x_diff) + (y_diff * y_diff)) as f32).sqrt();
     distance
 }
 
-fn quick_distance_from_to(x1 : i32, y1 : i32, x2 : i32, y2 : i32) -> f32{
+fn quick_distance_from_to(x1: i32, y1: i32, x2: i32, y2: i32) -> f32 {
     let x_diff = x1 - x2;
     let y_diff = y1 - y2;
     let distance = (x_diff.abs() + y_diff.abs()) as f32;
@@ -170,7 +187,7 @@ struct Cell {
     x: i32,
     y: i32,
     value: bool,
-    region : Rc<Region>
+    region: Rc<Region>,
 }
 
 impl Cell {
@@ -184,18 +201,18 @@ impl Cell {
     }
 }
 
-struct Region{
+struct Region {
     reg_x: i32,
     reg_y: i32,
     node: Option<Node>,
 }
 
-impl Region{
-    fn new(reg_x: i32, reg_y: i32) -> Region{
-        Region{
+impl Region {
+    fn new(reg_x: i32, reg_y: i32) -> Region {
+        Region {
             reg_x: reg_x,
             reg_y: reg_y,
-            node: None
+            node: None,
         }
     }
 }
@@ -207,10 +224,6 @@ struct Node {
 
 impl Node {
     fn new(x: i32, y: i32) -> Node {
-        Node {
-            x: x,
-            y: y,
-        }
+        Node { x: x, y: y }
     }
 }
-

--- a/src/worleynoise.rs
+++ b/src/worleynoise.rs
@@ -38,7 +38,7 @@ fn worley_noise(    density_as_str: &str,
     //we generate the actual noise by comparing the distance to the nearest node to the distance of the second nearest node and checking if it passes the threshold
     for row in 0..width as i32{
         for cell in 0..height as i32 {
-            dmsort::sort_by(&mut node_vec, |a,b| a.distance_to_sqrt(&cell,&row).partial_cmp( &b.distance_to_sqrt(&cell,&row))?);
+            dmsort::sort_by(&mut node_vec, |a,b| a.distance_to_sqrt(&cell,&row).partial_cmp( &b.distance_to_sqrt(&cell,&row)).unwrap()); //if this fails it means that the distance_to_sqrt function is not working correctly, scream FUCK
             let comparative_distance = (node_vec[0].distance_to_sqrt(&cell,&row) - node_vec[1].distance_to_sqrt(&cell,&row)).abs();
             if comparative_distance > positive_threshold {
                 zplane[cell as usize][row as usize] = true;

--- a/src/worleynoise.rs
+++ b/src/worleynoise.rs
@@ -1,0 +1,82 @@
+use crate::error::Result;
+use rand::*;
+use std::fmt::Write;
+
+byond_fn! { worley_generate(density, threshold, width, height) {
+    worley_noise(density, threshold, width, height).ok()
+} }
+
+//In the worst possible situation this is O(n^3) in the best possible O(n^2.5), so just keep it in mind.
+fn worley_noise(    density_as_str: &str,
+    positive_threshold_as_str: &str,
+    width_as_str: &str,
+    height_as_str: &str,
+) -> Result<String> {
+    let density = density_as_str.parse::<f64>().unwrap(); // density of noise, 0 means no nodes and 100 means that every tile has a node.
+    let positive_threshold = positive_threshold_as_str.parse::<f64>().unwrap(); // threshold, if value in cell is above this it gets set to true, otherwise false.
+    let width = width_as_str.parse::<usize>().unwrap();
+    let height = height_as_str.parse::<usize>().unwrap();
+
+    let mut rng = rand::thread_rng();
+
+    let mut zplane = vec![vec![false; width]; height];
+    let mut node_vec = Vec::new();
+
+    //we generate a node density map
+    while node_vec.len() < 2 {
+        for row in 0..width as i32 {
+            for cell in 0..height as i32 {
+                if rng.gen_range(0..100) <= density {
+                    let node = WorleyNode::new(row, cell);
+                    println!("{}", node);
+                    node_vec.push(node);
+
+                }
+            }
+        }
+    }
+
+    //we generate the actual noise by comparing the distance to the nearest node to the distance of the second nearest node and checking if it passes the threshold
+    for row in 0..width as i32{
+        for cell in 0..height as i32 {
+            dmsort::sort_by(&mut node_vec, |a,b| a.distance_to_sqrt(&cell,&row).partial_cmp( &b.distance_to_sqrt(&cell,&row)).unwrap());
+            let comparative_distance = (node_vec[0].distance_to_sqrt(&cell,&row) - node_vec[1].distance_to_sqrt(&cell,&row)).abs();
+            if comparative_distance > positive_threshold {
+                zplane[cell as usize][row as usize] = true;
+            }
+        }
+    }
+
+    //we write it to a string and spit it back out
+    let mut string = String::new();
+    for row in zplane.iter() {
+        for cell in row.iter() {
+            if *cell {
+                let _ = write!(string, "1");
+            } else {
+                let _ = write!(string, "0");
+            }
+
+        }
+    }
+
+   Ok(string);
+}
+
+
+struct WorleyNode{
+    x: i32,
+    y: i32,
+}
+
+impl WorleyNode {
+    fn new(x: i32, y: i32) -> Self {
+        Self { x, y}
+    }
+
+    fn distance_to_sqrt(&self, other_x: &i32, other_y: &i32) -> f64 {
+        let x_diff = self.x - other_x;
+        let y_diff = self.y - other_y;
+        f64::from(x_diff * x_diff + y_diff * y_diff).sqrt()
+    }
+}

--- a/src/worleynoise.rs
+++ b/src/worleynoise.rs
@@ -26,9 +26,8 @@ fn worley_noise(    density_as_str: &str,
     while node_vec.len() < 2 {
         for row in 0..width as i32 {
             for cell in 0..height as i32 {
-                if rng.gen_range(0..100) <= density {
+                if rng.gen_range(0..100) as f64 <= density {
                     let node = WorleyNode::new(row, cell);
-                    println!("{}", node);
                     node_vec.push(node);
 
                 }
@@ -60,7 +59,7 @@ fn worley_noise(    density_as_str: &str,
         }
     }
 
-   Ok(string);
+   Ok(string)
 }
 
 

--- a/src/worleynoise.rs
+++ b/src/worleynoise.rs
@@ -17,7 +17,8 @@ fn worley_noise(str_reg_size : &str, str_positive_threshold: &str, str_width: &s
     let width = str_width.parse::<i32>()?;
     let height = str_height.parse::<i32>()?;
 
-    let mut map = Map::new(region_size,width,height);
+    //i fucking mixed up width and height again. it really doesnt matter but here is a comment just warning you.
+    let mut map = Map::new(region_size,height,width);
 
     map.generate_noise(positive_threshold as f32);
 


### PR DESCRIPTION
Doing worley noise in DM is a performance suicide rust-g is the only option.

# Worley Noise!
This noise works by creating regions with nodes that are later mapped onto a set grid.

Each cell on the grid finds the nearest node in  neighbouring and it's own region, it then finds the second closest and subtracts the distance one from another.

If  it passes a threshold then congratulations, it is set to true.

# Samples
![obraz](https://user-images.githubusercontent.com/42111655/131908494-a0a6c18f-0dca-4d71-b7bf-9c2f68531d37.png)
![obraz](https://user-images.githubusercontent.com/42111655/131909416-0ba009e3-761f-45d5-9015-27491e51fdb1.png)
![obraz](https://user-images.githubusercontent.com/42111655/131910668-945c137d-b26f-458d-b0ab-67584c539e27.png)
![obraz](https://user-images.githubusercontent.com/42111655/132036350-c60df2d1-7ae0-4e7c-9ef8-b11959734b35.png)

