### PR TITLE
Functions for more precise time measurement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ dmsort = {version = "1.0.0", optional = true}
 toml-dep = { version = "0.5.8", package="toml", optional = true }
 
 [features]
-default = ["cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "toml", "url", "time"]
+default = ["cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "time", "toml", "url"]
 
 # default features
 cellularnoise = ["rand"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ dmsort = {version = "1.0.0", optional = true}
 toml-dep = { version = "0.5.8", package="toml", optional = true }
 
 [features]
-default = ["cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "toml", "url"]
+default = ["cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "toml", "url", "time"]
 
 # default features
 cellularnoise = ["rand"]
@@ -58,6 +58,7 @@ log = ["chrono"]
 sql = ["mysql", "serde", "serde_json", "once_cell", "dashmap", "jobs"]
 toml = ["serde", "serde_json", "toml-dep"]
 url = ["url-dep", "percent-encoding"]
+time = []
 
 # non-default features
 hash = ["base64", "const-random", "md-5", "hex", "sha-1", "sha2",  "twox-hash", "serde", "serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,9 @@ http = ["reqwest", "serde", "serde_json", "once_cell", "jobs"]
 json = ["serde", "serde_json"]
 log = ["chrono"]
 sql = ["mysql", "serde", "serde_json", "once_cell", "dashmap", "jobs"]
+time = []
 toml = ["serde", "serde_json", "toml-dep"]
 url = ["url-dep", "percent-encoding"]
-time = []
 
 # non-default features
 hash = ["base64", "const-random", "md-5", "hex", "sha-1", "sha2",  "twox-hash", "serde", "serde_json"]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The default features are:
 * sql: Asynchronous MySQL/MariaDB client library.
 * noise: 2d Perlin noise.
 * toml: TOML parser.
+* time: High-accuracy time measuring.
 
 Additional features are:
 * hash: Faster replacement for `md5`, support for SHA-1, SHA-256, and SHA-512. Requires OpenSSL on Linux.

--- a/dmsrc/time.dm
+++ b/dmsrc/time.dm
@@ -1,3 +1,3 @@
-#define rustg_time_microseconds(id) call(RUST_G, "time_microseconds")(id)
-#define rustg_time_milliseconds(id) call(RUST_G, "time_milliseconds")(id)
+#define rustg_time_microseconds(id) text2num(call(RUST_G, "time_microseconds")(id))
+#define rustg_time_milliseconds(id) text2num(call(RUST_G, "time_milliseconds")(id))
 #define rustg_time_reset(id) call(RUST_G, "time_reset")(id)

--- a/dmsrc/time.dm
+++ b/dmsrc/time.dm
@@ -1,0 +1,3 @@
+#define rustg_time_microseconds(id) call(RUST_G, "time_microseconds")(id)
+#define rustg_time_milliseconds(id) call(RUST_G, "time_milliseconds")(id)
+#define rustg_time_reset(id) call(RUST_G, "time_reset")(id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ pub mod unzip;
 pub mod url;
 #[cfg(feature = "worleynoise")]
 pub mod worleynoise;
+#[cfg(feature = "time")]
+pub mod time;
 
 #[cfg(not(target_pointer_width = "32"))]
 compile_error!("rust-g must be compiled for a 32-bit target");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub mod log;
 pub mod noise_gen;
 #[cfg(feature = "sql")]
 pub mod sql;
+#[cfg(feature = "time")]
+pub mod time;
 #[cfg(feature = "toml")]
 pub mod toml;
 #[cfg(feature = "unzip")]
@@ -34,8 +36,6 @@ pub mod unzip;
 pub mod url;
 #[cfg(feature = "worleynoise")]
 pub mod worleynoise;
-#[cfg(feature = "time")]
-pub mod time;
 
 #[cfg(not(target_pointer_width = "32"))]
 compile_error!("rust-g must be compiled for a 32-bit target");

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,11 +1,10 @@
 use std::{
     cell::RefCell,
     collections::hash_map::{Entry, HashMap},
-    ffi::OsString,
     time::Instant,
 };
 
-thread_local!( static INSTANTS: RefCell<HashMap<OsString, Instant>> = RefCell::new(HashMap::new()) );
+thread_local!( static INSTANTS: RefCell<HashMap<String, Instant>> = RefCell::new(HashMap::new()) );
 
 byond_fn! { time_microseconds(instant_id) {
     INSTANTS.with(|instants| {

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,39 @@
+use std::{
+    cell::RefCell,
+    collections::hash_map::{Entry, HashMap},
+    ffi::OsString,
+    time::Instant,
+};
+
+thread_local!( static INSTANTS: RefCell<HashMap<OsString, Instant>> = RefCell::new(HashMap::new()) );
+
+byond_fn! { time_microseconds(instant_id) {
+    INSTANTS.with(|instants| {
+        let mut map = instants.borrow_mut();
+        let instant = match map.entry(instant_id.into()) {
+            Entry::Occupied(elem) => elem.into_mut(),
+            Entry::Vacant(elem) => elem.insert(Instant::now()),
+        };
+        Some(instant.elapsed().as_micros().to_string())
+    })
+} }
+
+byond_fn! { time_milliseconds(instant_id) {
+    INSTANTS.with(|instants| {
+        let mut map = instants.borrow_mut();
+        let instant = match map.entry(instant_id.into()) {
+            Entry::Occupied(elem) => elem.into_mut(),
+            Entry::Vacant(elem) => elem.insert(Instant::now()),
+        };
+        Some(instant.elapsed().as_millis().to_string())
+    })
+} }
+
+byond_fn! { time_reset(instant_id) {
+    INSTANTS.with(|instants| {
+        let mut map = instants.borrow_mut();
+        map.insert(instant_id.into(), Instant::now());
+        Some("")
+    })
+} }
+


### PR DESCRIPTION
Adds `time_reset`, `time_microseconds` and `time_milliseconds` BYOND-accessible functions which can be used to create and reset multiple "timers" and track time since they were last reset more precisely than it is possible in BYOND itself. I personally mostly intend to use these for some detailed live profiling in some performance-problematic parts of https://github.com/goonstation/goonstation but maybe other people can use these too.

I tested that these work but yell at me if I forgot anything or screwed up as Rust is not the language I use most of the time, thanks.