### PR TITLE
Aho-Corasick string replacements to help clean up replaceText spam

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,10 @@ zip = { version = "0.5.8", optional = true }
 rand = {version = "0.8", optional = true}
 dmsort = {version = "1.0.0", optional = true}
 toml-dep = { version = "0.5.8", package="toml", optional = true }
+aho-corasick = { version = "0.7.18", optional = true}
 
 [features]
-default = ["cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "time", "toml", "url"]
+default = ["cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "time", "toml", "url", "acreplace"]
 
 # default features
 cellularnoise = ["rand"]
@@ -59,6 +60,7 @@ sql = ["mysql", "serde", "serde_json", "once_cell", "dashmap", "jobs"]
 time = []
 toml = ["serde", "serde_json", "toml-dep"]
 url = ["url-dep", "percent-encoding"]
+acreplace = ["aho-corasick"]
 
 # non-default features
 hash = ["base64", "const-random", "md-5", "hex", "sha-1", "sha2",  "twox-hash", "serde", "serde_json"]

--- a/dmsrc/acreplace.dm
+++ b/dmsrc/acreplace.dm
@@ -1,0 +1,2 @@
+#define rustg_setup_acreplace(text, patterns, replacements) call(RUST_G, "setup_acreplace")(text, json_encode(patterns), json_encode(replacements))
+#define rustg_acreplace(key, text) call(RUST_G, "acreplace")(key, text)

--- a/src/acreplace.rs
+++ b/src/acreplace.rs
@@ -1,0 +1,38 @@
+use aho_corasick::AhoCorasickBuilder;
+use aho_corasick::AhoCorasick;
+use std::{
+    cell::RefCell,
+    collections::hash_map::HashMap
+};
+
+struct Replacements {
+    pub automaton: AhoCorasick,
+    pub replacements: Vec<String>
+}
+
+thread_local! {
+    static CREPLACE_MAP: RefCell<HashMap<String, Replacements>> = RefCell::new(HashMap::new());
+}
+
+byond_fn! { setup_acreplace(key, patternsjson, replacementsjson) {
+    let patterns: Vec<String> = serde_json::from_str(patternsjson.clone()).ok()?;
+    let replacements: Vec<String> = serde_json::from_str(replacementsjson.clone()).ok()?;
+    let ac = AhoCorasickBuilder::new().auto_configure(&patterns).build(&patterns);
+    CREPLACE_MAP.with(|cell| {
+        let mut map = cell.borrow_mut();
+        map.insert(key.to_owned(), Replacements { automaton: ac, replacements: replacements });
+    });
+    Some("")
+} }
+
+
+byond_fn! { acreplace(key, text) {
+    CREPLACE_MAP.with(|cell| -> Option<String> {
+        let map = cell.borrow_mut();
+        match map.get(&key.to_owned()) {
+            Some(replacements) => Some(replacements.automaton.replace_all(text, &replacements.replacements)),
+            None => None
+        }
+    })
+} }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ pub mod unzip;
 pub mod url;
 #[cfg(feature = "worleynoise")]
 pub mod worleynoise;
+#[cfg(feature = "acreplace")]
+pub mod acreplace;
 
 #[cfg(not(target_pointer_width = "32"))]
 compile_error!("rust-g must be compiled for a 32-bit target");


### PR DESCRIPTION
Quite a few codebases have procs that look like 20 lines of `message = replacetext(message, " foo ", " ")`, with this handy trick you can make that code look like 
```
/proc/replacesomestuff(var/string)
var/static/_testsetup
if (!_testsetup)
	rustg_setup_acreplace("testkey", list("a","b","c"), list("d", "e", "f"))
	_testsetup = 1
return rustg_acreplace("testkey", string)
```

The aho-corasick crate only adds `memchr` as a dependency, so the feature should be fairly slim and I feel its inclusion in the default features is justified.

The underlying crate is very powerful and can provide both case-sensitive and insensitive replacing as well as matching with multiple different match semantics. Only the bare minimum for what I needed is implemented. The good stuff is at https://docs.rs/aho-corasick/latest/aho_corasick/struct.AhoCorasickBuilder.html

Replacing the constant parts of goon's shakespearify proc with this, I was able to benchmark the following:
```json
	{
		"name": "/proc/shakespearify",
		"self": 2.319,
		"total": 2.319,
		"real": 2.322,
		"over": 2.297,
		"calls": 5000
	},
	{
		"name": "/proc/shakespearify_new",
		"self": 0.356,
		"total": 0.356,
		"real": 0.358,
		"over": 0.353,
		"calls": 5000
	},
```