### PR TITLE
Cleanups and additions for the Aho-Corasick replacement stuff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,10 @@ toml-dep = { version = "0.5.8", package="toml", optional = true }
 aho-corasick = { version = "0.7.18", optional = true}
 
 [features]
-default = ["cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "time", "toml", "url", "acreplace"]
+default = ["acreplace", "cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "time", "toml", "url"]
 
 # default features
+acreplace = ["aho-corasick"]
 cellularnoise = ["rand"]
 dmi = ["png", "image"]
 file = []
@@ -60,7 +61,6 @@ sql = ["mysql", "serde", "serde_json", "once_cell", "dashmap", "jobs"]
 time = []
 toml = ["serde", "serde_json", "toml-dep"]
 url = ["url-dep", "percent-encoding"]
-acreplace = ["aho-corasick"]
 
 # non-default features
 hash = ["base64", "const-random", "md-5", "hex", "sha-1", "sha2",  "twox-hash", "serde", "serde_json"]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ cargo build --release --target i686-pc-windows-msvc
 To get additional features, pass a list to `--features`, for example `--features hash,url`. To get all features, pass `--all-features`. To disable the default features, pass `--no-default-features`.
 
 The default features are:
+* acreplace: Aho-Corasick string matching and replacement.
 * cellularnoise: Function to generate cellular automata-based noise.
 * dmi: DMI manipulations which are impossible from within BYOND.
   Used by the asset cache subsystem to improve load times.
@@ -86,11 +87,10 @@ The default features are:
 * http: Asynchronous HTTP(s) client supporting most standard methods.
 * json: Function to check JSON validity.
 * log: Faster log output.
-* sql: Asynchronous MySQL/MariaDB client library.
 * noise: 2d Perlin noise.
-* toml: TOML parser.
+* sql: Asynchronous MySQL/MariaDB client library.
 * time: High-accuracy time measuring.
-* acreplace: Aho-Corasick string matching and replacement.
+* toml: TOML parser.
 
 Additional features are:
 * hash: Faster replacement for `md5`, support for SHA-1, SHA-256, and SHA-512. Requires OpenSSL on Linux.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The default features are:
 * noise: 2d Perlin noise.
 * toml: TOML parser.
 * time: High-accuracy time measuring.
+* acreplace: Aho-Corasick string matching and replacement.
 
 Additional features are:
 * hash: Faster replacement for `md5`, support for SHA-1, SHA-256, and SHA-512. Requires OpenSSL on Linux.

--- a/dmsrc/acreplace.dm
+++ b/dmsrc/acreplace.dm
@@ -1,2 +1,42 @@
-#define rustg_setup_acreplace(text, patterns, replacements) call(RUST_G, "setup_acreplace")(text, json_encode(patterns), json_encode(replacements))
+
+/**
+ * Sets up the Aho-Corasick automaton with its default options.
+ *
+ * The search patterns list and the replacements must be of the same length when replace is run, but an empty replacements list is allowed if replacements are supplied with the replace call
+ * Arguments:
+ * * key - The key for the automaton, to be used with subsequent rustg_acreplace/rustg_acreplace_with_replacements calls
+ * * patterns - A non-associative list of strings to search for
+ * * replacements - Default replacements for this automaton, used with rustg_acreplace
+ */
+#define rustg_setup_acreplace(key, patterns, replacements) call(RUST_G, "setup_acreplace")(key, json_encode(patterns), json_encode(replacements))
+
+/**
+ * Sets up the Aho-Corasick automaton using supplied options.
+ *
+ * The search patterns list and the replacements must be of the same length when replace is run, but an empty replacements list is allowed if replacements are supplied with the replace call
+ * Arguments:
+ * * key - The key for the automaton, to be used with subsequent rustg_acreplace/rustg_acreplace_with_replacements calls
+ * * options - An associative list like list("anchored" = 0, "ascii_case_insensitive" = 0, "match_kind" = "Standard"). The values shown on the example are the defaults, and default values may be omitted. See the identically named methods at https://docs.rs/aho-corasick/latest/aho_corasick/struct.AhoCorasickBuilder.html to see what the options do.
+ * * patterns - A non-associative list of strings to search for
+ * * replacements - Default replacements for this automaton, used with rustg_acreplace
+ */
+#define rustg_setup_acreplace_with_options(key, options, patterns, replacements) call(RUST_G, "setup_acreplace")(key, json_encode(options), json_encode(patterns), json_encode(replacements))
+
+/**
+ * Run the specified replacement engine with the provided haystack text to replace, returning replaced text.
+ *
+ * Arguments:
+ * * key - The key for the automaton
+ * * text - Text to run replacements on
+ */
 #define rustg_acreplace(key, text) call(RUST_G, "acreplace")(key, text)
+
+/**
+ * Run the specified replacement engine with the provided haystack text to replace, returning replaced text.
+ *
+ * Arguments:
+ * * key - The key for the automaton
+ * * text - Text to run replacements on
+ * * replacements - Replacements for this call. Must be the same length as the set-up patterns
+ */
+#define rustg_acreplace_with_replacements(key, text, replacements) call(RUST_G, "acreplace_with_replacements")(key, text, json_encode(replacements))

--- a/src/acreplace.rs
+++ b/src/acreplace.rs
@@ -36,8 +36,8 @@ where
     D: serde::de::Deserializer<'de>,
 {
     match u8::deserialize(deserializer)? {
-        1 => Ok(true),
-        _ => Ok(false),
+        0 => Ok(false),
+        _ => Ok(true),
     }
 }
 
@@ -83,7 +83,7 @@ byond_fn! { setup_acreplace_with_options(key, options_json, patterns_json, repla
 byond_fn! { acreplace(key, text) {
     CREPLACE_MAP.with(|cell| -> Option<String> {
         let map = cell.borrow_mut();
-        let replacements = map.get(&key.to_owned())?;
+        let replacements = map.get(key)?;
         Some(replacements.automaton.replace_all(text, &replacements.replacements))
     })
 } }
@@ -92,7 +92,7 @@ byond_fn! { acreplace_with_replacements(key, text, replacements_json) {
     let call_replacements: Vec<String> = serde_json::from_str(&replacements_json).ok()?;
     CREPLACE_MAP.with(|cell| -> Option<String> {
         let map = cell.borrow_mut();
-        let replacements = map.get(&key.to_owned())?;
+        let replacements = map.get(key)?;
         Some(replacements.automaton.replace_all(text, &call_replacements))
     })
 }}

--- a/src/acreplace.rs
+++ b/src/acreplace.rs
@@ -1,23 +1,77 @@
-use aho_corasick::AhoCorasickBuilder;
-use aho_corasick::AhoCorasick;
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
 use std::{
     cell::RefCell,
     collections::hash_map::HashMap
 };
+use serde::Deserialize;
 
 struct Replacements {
     pub automaton: AhoCorasick,
-    pub replacements: Vec<String>
+    pub replacements: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct AhoCorasickOptions {
+    #[serde(default, deserialize_with = "deserialize_byond_bool")]
+    pub anchored: bool,
+    #[serde(default, deserialize_with = "deserialize_byond_bool")]
+    pub ascii_case_insensitive: bool,
+    #[serde(default, deserialize_with = "deserialize_matchkind")]
+    pub match_kind: MatchKind,
+}
+
+impl AhoCorasickOptions {
+    fn auto_configure_and_build(&self, patterns: &Vec<String>) -> AhoCorasick {
+        AhoCorasickBuilder::new()
+        .anchored(self.anchored)
+        .ascii_case_insensitive(self.ascii_case_insensitive)
+        .match_kind(self.match_kind)
+        .auto_configure(patterns)
+        .build(patterns)
+    }
+}
+
+fn deserialize_byond_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    match u8::deserialize(deserializer)? {
+        1 => Ok(true),
+        _ => Ok(false),
+    }
+}
+
+fn deserialize_matchkind<'de, D>(deserializer: D) -> Result<MatchKind, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    match String::deserialize(deserializer)?.as_ref() {
+        "LeftmostFirst" => Ok(MatchKind::LeftmostFirst),
+        "LeftmostLongest" => Ok(MatchKind::LeftmostLongest),
+        _ => Ok(MatchKind::Standard),
+    }
 }
 
 thread_local! {
     static CREPLACE_MAP: RefCell<HashMap<String, Replacements>> = RefCell::new(HashMap::new());
 }
 
-byond_fn! { setup_acreplace(key, patternsjson, replacementsjson) {
-    let patterns: Vec<String> = serde_json::from_str(patternsjson.clone()).ok()?;
-    let replacements: Vec<String> = serde_json::from_str(replacementsjson.clone()).ok()?;
+byond_fn! { setup_acreplace(key, patterns_json, replacements_json) {
+    let patterns: Vec<String> = serde_json::from_str(&patterns_json).ok()?;
+    let replacements: Vec<String> = serde_json::from_str(&replacements_json).ok()?;
     let ac = AhoCorasickBuilder::new().auto_configure(&patterns).build(&patterns);
+    CREPLACE_MAP.with(|cell| {
+        let mut map = cell.borrow_mut();
+        map.insert(key.to_owned(), Replacements { automaton: ac, replacements: replacements });
+    });
+    Some("")
+} }
+
+byond_fn! { setup_acreplace_with_options(key, options_json, patterns_json, replacements_json) {
+    let options: AhoCorasickOptions = serde_json::from_str(&options_json).ok()?;
+    let patterns: Vec<String> = serde_json::from_str(&patterns_json).ok()?;
+    let replacements: Vec<String> = serde_json::from_str(&replacements_json).ok()?;
+    let ac = options.auto_configure_and_build(&patterns);
     CREPLACE_MAP.with(|cell| {
         let mut map = cell.borrow_mut();
         map.insert(key.to_owned(), Replacements { automaton: ac, replacements: replacements });
@@ -29,10 +83,17 @@ byond_fn! { setup_acreplace(key, patternsjson, replacementsjson) {
 byond_fn! { acreplace(key, text) {
     CREPLACE_MAP.with(|cell| -> Option<String> {
         let map = cell.borrow_mut();
-        match map.get(&key.to_owned()) {
-            Some(replacements) => Some(replacements.automaton.replace_all(text, &replacements.replacements)),
-            None => None
-        }
+        let replacements = map.get(&key.to_owned())?;
+        Some(replacements.automaton.replace_all(text, &replacements.replacements))
     })
 } }
+
+byond_fn! { acreplace_with_replacements(key, text, replacements_json) {
+    let call_replacements: Vec<String> = serde_json::from_str(&replacements_json).ok()?;
+    CREPLACE_MAP.with(|cell| -> Option<String> {
+        let map = cell.borrow_mut();
+        let replacements = map.get(&key.to_owned())?;
+        Some(replacements.automaton.replace_all(text, &call_replacements))
+    })
+}}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ mod error;
 #[cfg(feature = "jobs")]
 mod jobs;
 
+#[cfg(feature = "acreplace")]
+pub mod acreplace;
 #[cfg(feature = "cellularnoise")]
 pub mod cellularnoise;
 #[cfg(feature = "dmi")]
@@ -36,8 +38,7 @@ pub mod unzip;
 pub mod url;
 #[cfg(feature = "worleynoise")]
 pub mod worleynoise;
-#[cfg(feature = "acreplace")]
-pub mod acreplace;
+
 
 #[cfg(not(target_pointer_width = "32"))]
 compile_error!("rust-g must be compiled for a 32-bit target");


### PR DESCRIPTION
Most notably adds an option to make case-insensitive replacements. Other options are provided as a courtesy. Fiddly DFA/NFA settings are not provided as auto_configure automagically sets up DFA if the matches array has less than 100 items.