### PR TITLE
Fix clippy lints, Rustfmt, put both on CI, and update Cargo.lock

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,12 +15,12 @@ jobs:
         with:
           toolchain: stable
           target: i686-pc-windows-msvc
-      - name: Check (all features)
+      - name: Clippy (all features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
-          command: check
-          args: --target i686-pc-windows-msvc --all-features
+          command: clippy
+          args: --target i686-pc-windows-msvc --all-features -- -D warnings
       - name: Build (release) (default features)
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,12 +15,20 @@ jobs:
         with:
           toolchain: stable
           target: i686-pc-windows-msvc
+          components: rustfmt, clippy
       - name: Clippy (all features)
+        uses: actions-rs/clippy-check@v1
+        with:
+          toolchain: stable
+          token: ${{ secrets.GITHUB_TOKEN }}
+          command: clippy
+          args: --target i686-pc-windows-msvc --all-features -- -D warnings
+      - name: Rustfmt
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
-          command: clippy
-          args: --target i686-pc-windows-msvc --all-features -- -D warnings
+          command: fmt
+          args: -- --check
       - name: Build (release) (default features)
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           toolchain: stable
           token: ${{ secrets.GITHUB_TOKEN }}
-          command: clippy
           args: --target i686-pc-windows-msvc --all-features -- -D warnings
       - name: Rustfmt
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,7 @@ dependencies = [
 name = "rust-g"
 version = "0.5.0"
 dependencies = [
+ "aho-corasick",
  "base64 0.13.0",
  "chrono",
  "const-random",

--- a/build.rs
+++ b/build.rs
@@ -30,7 +30,12 @@ fn main() {
         if let Some(uprfeature) = key.strip_prefix("CARGO_FEATURE_") {
             let feature = uprfeature.to_lowercase().replace("_", "-"); // actual proper name of the enabled feature
             if feature_dm_exists!(&feature) {
-                writeln!(f, "{}", std::fs::read_to_string(feature_dm_file!(&feature)).unwrap()).unwrap();
+                writeln!(
+                    f,
+                    "{}",
+                    std::fs::read_to_string(feature_dm_file!(&feature)).unwrap()
+                )
+                .unwrap();
             }
         }
     }

--- a/src/acreplace.rs
+++ b/src/acreplace.rs
@@ -57,24 +57,24 @@ thread_local! {
 }
 
 byond_fn! { setup_acreplace(key, patterns_json, replacements_json) {
-    let patterns: Vec<String> = serde_json::from_str(&patterns_json).ok()?;
-    let replacements: Vec<String> = serde_json::from_str(&replacements_json).ok()?;
+    let patterns: Vec<String> = serde_json::from_str(patterns_json).ok()?;
+    let replacements: Vec<String> = serde_json::from_str(replacements_json).ok()?;
     let ac = AhoCorasickBuilder::new().auto_configure(&patterns).build(&patterns);
     CREPLACE_MAP.with(|cell| {
         let mut map = cell.borrow_mut();
-        map.insert(key.to_owned(), Replacements { automaton: ac, replacements: replacements });
+        map.insert(key.to_owned(), Replacements { automaton: ac, replacements });
     });
     Some("")
 } }
 
 byond_fn! { setup_acreplace_with_options(key, options_json, patterns_json, replacements_json) {
-    let options: AhoCorasickOptions = serde_json::from_str(&options_json).ok()?;
-    let patterns: Vec<String> = serde_json::from_str(&patterns_json).ok()?;
-    let replacements: Vec<String> = serde_json::from_str(&replacements_json).ok()?;
+    let options: AhoCorasickOptions = serde_json::from_str(options_json).ok()?;
+    let patterns: Vec<String> = serde_json::from_str(patterns_json).ok()?;
+    let replacements: Vec<String> = serde_json::from_str(replacements_json).ok()?;
     let ac = options.auto_configure_and_build(&patterns);
     CREPLACE_MAP.with(|cell| {
         let mut map = cell.borrow_mut();
-        map.insert(key.to_owned(), Replacements { automaton: ac, replacements: replacements });
+        map.insert(key.to_owned(), Replacements { automaton: ac, replacements });
     });
     Some("")
 } }
@@ -89,7 +89,7 @@ byond_fn! { acreplace(key, text) {
 } }
 
 byond_fn! { acreplace_with_replacements(key, text, replacements_json) {
-    let call_replacements: Vec<String> = serde_json::from_str(&replacements_json).ok()?;
+    let call_replacements: Vec<String> = serde_json::from_str(replacements_json).ok()?;
     CREPLACE_MAP.with(|cell| -> Option<String> {
         let map = cell.borrow_mut();
         let replacements = map.get(key)?;

--- a/src/acreplace.rs
+++ b/src/acreplace.rs
@@ -1,9 +1,6 @@
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
-use std::{
-    cell::RefCell,
-    collections::hash_map::HashMap
-};
 use serde::Deserialize;
+use std::{cell::RefCell, collections::hash_map::HashMap};
 
 struct Replacements {
     pub automaton: AhoCorasick,
@@ -21,13 +18,13 @@ struct AhoCorasickOptions {
 }
 
 impl AhoCorasickOptions {
-    fn auto_configure_and_build(&self, patterns: &Vec<String>) -> AhoCorasick {
+    fn auto_configure_and_build(&self, patterns: &[String]) -> AhoCorasick {
         AhoCorasickBuilder::new()
-        .anchored(self.anchored)
-        .ascii_case_insensitive(self.ascii_case_insensitive)
-        .match_kind(self.match_kind)
-        .auto_configure(patterns)
-        .build(patterns)
+            .anchored(self.anchored)
+            .ascii_case_insensitive(self.ascii_case_insensitive)
+            .match_kind(self.match_kind)
+            .auto_configure(patterns)
+            .build(patterns)
     }
 }
 
@@ -79,7 +76,6 @@ byond_fn! { setup_acreplace_with_options(key, options_json, patterns_json, repla
     Some("")
 } }
 
-
 byond_fn! { acreplace(key, text) {
     CREPLACE_MAP.with(|cell| -> Option<String> {
         let map = cell.borrow_mut();
@@ -96,4 +92,3 @@ byond_fn! { acreplace_with_replacements(key, text, replacements_json) {
         Some(replacements.automaton.replace_all(text, &call_replacements))
     })
 }}
-

--- a/src/byond.rs
+++ b/src/byond.rs
@@ -15,7 +15,7 @@ pub unsafe fn parse_args<'a>(argc: c_int, argv: *const *const c_char) -> Vec<Cow
     unsafe {
         slice::from_raw_parts(argv, argc as usize)
             .iter()
-            .map(|ptr| unsafe { CStr::from_ptr(*ptr) })
+            .map(|ptr| CStr::from_ptr(*ptr))
             .map(|cstr| cstr.to_string_lossy())
             .collect()
     }

--- a/src/byond.rs
+++ b/src/byond.rs
@@ -12,11 +12,13 @@ thread_local! {
 }
 
 pub unsafe fn parse_args<'a>(argc: c_int, argv: *const *const c_char) -> Vec<Cow<'a, str>> {
-    slice::from_raw_parts(argv, argc as usize)
-        .iter()
-        .map(|ptr| CStr::from_ptr(*ptr))
-        .map(|cstr| cstr.to_string_lossy())
-        .collect()
+    unsafe {
+        slice::from_raw_parts(argv, argc as usize)
+            .iter()
+            .map(|ptr| unsafe { CStr::from_ptr(*ptr) })
+            .map(|cstr| cstr.to_string_lossy())
+            .collect()
+    }
 }
 
 pub fn byond_return(value: Option<Vec<u8>>) -> *const c_char {
@@ -56,7 +58,7 @@ macro_rules! byond_fn {
     ($name:ident($($arg:ident),* $(, ...$rest:ident)?) $body:block) => {
         #[no_mangle]
         #[allow(clippy::missing_safety_doc)]
-        pub extern "C" fn $name(
+        pub unsafe extern "C" fn $name(
             _argc: ::std::os::raw::c_int, _argv: *const *const ::std::os::raw::c_char
         ) -> *const ::std::os::raw::c_char {
             let __args = unsafe { $crate::byond::parse_args(_argc, _argv) };

--- a/src/cellularnoise.rs
+++ b/src/cellularnoise.rs
@@ -79,7 +79,6 @@ fn noise_gen(
                 } else {
                     zplane[i][j] = false;
                 }
-
             }
         }
     }

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -27,7 +27,7 @@ byond_fn! { dmi_resize_png(path, width, height, resizetype) {
 
 fn strip_metadata(path: &str) -> Result<()> {
     let (info, image) = read_png(path)?;
-    Ok(write_png(path, info, image)?)
+    write_png(path, info, image)
 }
 
 fn read_png(path: &str) -> Result<(OutputInfo, Vec<u8>)> {

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -53,7 +53,7 @@ fn create_png(path: &str, width: &str, height: &str, data: &str) -> Result<()> {
 
     let bytes = data.as_bytes();
     if bytes.len() % 7 != 0 {
-        return Err(Error::InvalidPngDataError);
+        return Err(Error::InvalidPngData);
     }
 
     let mut result: Vec<u8> = Vec::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,29 +35,29 @@ pub enum Error {
     #[error(transparent)]
     ImageEncoding(#[from] EncodingError),
     #[error(transparent)]
-    ParseIntError(#[from] ParseIntError),
+    ParseInt(#[from] ParseIntError),
     #[error(transparent)]
-    ParseFloatError(#[from] ParseFloatError),
+    ParseFloat(#[from] ParseFloatError),
     #[error(transparent)]
-    GenericImageError(#[from] ImageError),
+    GenericImage(#[from] ImageError),
     #[cfg(feature = "png")]
     #[error("Invalid png data.")]
-    InvalidPngDataError,
+    InvalidPngData,
     #[cfg(feature = "http")]
     #[error(transparent)]
-    RequestError(#[from] reqwest::Error),
+    Request(#[from] reqwest::Error),
     #[cfg(feature = "toml")]
     #[error(transparent)]
-    TomlDeserializationError(#[from] toml_dep::de::Error),
+    TomlDeserialization(#[from] toml_dep::de::Error),
     #[cfg(feature = "http")]
     #[error(transparent)]
-    SerializationError(#[from] serde_json::Error),
+    Serialization(#[from] serde_json::Error),
     #[cfg(feature = "unzip")]
     #[error(transparent)]
-    UnzipError(#[from] ZipError),
+    Unzip(#[from] ZipError),
     #[cfg(feature = "hash")]
     #[error("Unable to decode hex value.")]
-    HexDecodeError,
+    HexDecode,
 }
 
 impl From<Utf8Error> for Error {

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -107,7 +107,7 @@ fn totp_generate(hex_seed: &str, offset: i64, time_override: Option<i64>) -> Res
 
     match hex::decode_to_slice(hex_seed, &mut seed[..10] as &mut [u8]) {
         Ok(value) => value,
-        Err(_) => return Err(Error::HexDecodeError),
+        Err(_) => return Err(Error::HexDecode),
     };
 
     let ipad: [u8; 64] = seed.map(|x| x ^ 0x36); // HMAC Step 4

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -72,7 +72,7 @@ fn hash_algorithm<B: AsRef<[u8]>>(name: &str, bytes: B) -> Result<String> {
 }
 
 fn string_hash(algorithm: &str, string: &str) -> Result<String> {
-    Ok(hash_algorithm(algorithm, string)?)
+    hash_algorithm(algorithm, string)
 }
 
 fn file_hash(algorithm: &str, path: &str) -> Result<String> {
@@ -80,7 +80,7 @@ fn file_hash(algorithm: &str, path: &str) -> Result<String> {
     let mut file = BufReader::new(File::open(path)?);
     file.read_to_end(&mut bytes)?;
 
-    Ok(hash_algorithm(algorithm, &bytes)?)
+    hash_algorithm(algorithm, &bytes)
 }
 
 /// Generates multiple TOTP codes from 20 character hex_seed, with time step +-tolerance

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -114,14 +114,14 @@ fn totp_generate(hex_seed: &str, offset: i64, time_override: Option<i64>) -> Res
     let opad: [u8; 64] = seed.map(|x| x ^ 0x5C); // HMAC Step 7
 
     // Will panic if the date is not between Jan 1 1970 and the year ~200 billion
-    let curr_time: i64 = time_override.unwrap_or(
+    let curr_time: i64 = time_override.unwrap_or_else(|| {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("SystemTime is before Unix Epoc")
             .as_secs()
             .try_into()
-            .unwrap(),
-    ) / 30;
+            .unwrap()
+    }) / 30;
     let time: u64 = (curr_time + offset) as u64;
 
     let time_bytes: [u8; 8] = time.to_be_bytes();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 #[macro_use]
 mod byond;
 #[allow(dead_code)]
@@ -38,7 +40,6 @@ pub mod unzip;
 pub mod url;
 #[cfg(feature = "worleynoise")]
 pub mod worleynoise;
-
 
 #[cfg(not(target_pointer_width = "32"))]
 compile_error!("rust-g must be compiled for a 32-bit target");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 #[macro_use]
 mod byond;

--- a/src/log.rs
+++ b/src/log.rs
@@ -18,7 +18,7 @@ byond_fn! { log_write(path, data, ...rest) {
     FILE_MAP.with(|cell| -> Result<()> {
         // open file
         let mut map = cell.borrow_mut();
-        let path = Path::new(&path as &str);
+        let path = Path::new(path as &str);
         let file = match map.entry(path.into()) {
             Entry::Occupied(elem) => elem.into_mut(),
             Entry::Vacant(elem) => elem.insert(open(path)?),

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -168,7 +168,7 @@ fn do_query(handle: &str, query: &str, params: &str) -> Result<serde_json::Value
             let converted = match value {
                 mysql::Value::Bytes(b) => match ctype {
                     MYSQL_TYPE_VARCHAR | MYSQL_TYPE_STRING | MYSQL_TYPE_VAR_STRING => {
-                        serde_json::Value::String(String::from_utf8_lossy(&b).into_owned())
+                        serde_json::Value::String(String::from_utf8_lossy(b).into_owned())
                     }
                     MYSQL_TYPE_BLOB
                     | MYSQL_TYPE_LONG_BLOB
@@ -181,7 +181,7 @@ fn do_query(handle: &str, query: &str, params: &str) -> Result<serde_json::Value
                                     .collect(),
                             )
                         } else {
-                            serde_json::Value::String(String::from_utf8_lossy(&b).into_owned())
+                            serde_json::Value::String(String::from_utf8_lossy(b).into_owned())
                         }
                     }
                     _ => serde_json::Value::Null,

--- a/src/time.rs
+++ b/src/time.rs
@@ -35,4 +35,3 @@ byond_fn! { time_reset(instant_id) {
         Some("")
     })
 } }
-

--- a/src/unzip.rs
+++ b/src/unzip.rs
@@ -21,7 +21,7 @@ fn construct_unzip(url: &str, unzip_directory: &str) -> UnzipPrep {
 }
 
 byond_fn! { unzip_download_async(url, unzip_directory) {
-    let unzip = construct_unzip(&url, &unzip_directory);
+    let unzip = construct_unzip(url, unzip_directory);
     Some(jobs::start(move ||
         do_unzip_download(unzip).unwrap_or_else(|e| e.to_string())
     ))

--- a/src/worleynoise.rs
+++ b/src/worleynoise.rs
@@ -172,14 +172,14 @@ impl Map {
 fn distance_from_to(x1: i32, y1: i32, x2: i32, y2: i32) -> f32 {
     let x_diff = x1 - x2;
     let y_diff = y1 - y2;
-    
+
     (((x_diff * x_diff) + (y_diff * y_diff)) as f32).sqrt()
 }
 
 fn quick_distance_from_to(x1: i32, y1: i32, x2: i32, y2: i32) -> f32 {
     let x_diff = x1 - x2;
     let y_diff = y1 - y2;
-    
+
     (x_diff.abs() + y_diff.abs()) as f32
 }
 

--- a/src/worleynoise.rs
+++ b/src/worleynoise.rs
@@ -54,12 +54,12 @@ struct Map {
 impl Map {
     fn new(region_size: i32, cell_map_width: i32, cell_map_height: i32, node_chance: f32) -> Map {
         let mut map = Map {
-            region_size: region_size,
+            region_size,
             region_map: Vec::new(),
             cell_map: Vec::new(),
-            cell_map_width: cell_map_width,
-            cell_map_height: cell_map_height,
-            node_chance: node_chance,
+            cell_map_width,
+            cell_map_height,
+            node_chance,
         };
 
         map.init_regions();
@@ -172,15 +172,15 @@ impl Map {
 fn distance_from_to(x1: i32, y1: i32, x2: i32, y2: i32) -> f32 {
     let x_diff = x1 - x2;
     let y_diff = y1 - y2;
-    let distance = (((x_diff * x_diff) + (y_diff * y_diff)) as f32).sqrt();
-    distance
+    
+    (((x_diff * x_diff) + (y_diff * y_diff)) as f32).sqrt()
 }
 
 fn quick_distance_from_to(x1: i32, y1: i32, x2: i32, y2: i32) -> f32 {
     let x_diff = x1 - x2;
     let y_diff = y1 - y2;
-    let distance = (x_diff.abs() + y_diff.abs()) as f32;
-    distance
+    
+    (x_diff.abs() + y_diff.abs()) as f32
 }
 
 struct Cell {
@@ -193,10 +193,10 @@ struct Cell {
 impl Cell {
     fn new(x: i32, y: i32, region: Rc<Region>) -> Cell {
         Cell {
-            x: x,
-            y: y,
+            x,
+            y,
             value: false,
-            region: region,
+            region,
         }
     }
 }
@@ -210,8 +210,8 @@ struct Region {
 impl Region {
     fn new(reg_x: i32, reg_y: i32) -> Region {
         Region {
-            reg_x: reg_x,
-            reg_y: reg_y,
+            reg_x,
+            reg_y,
             node: None,
         }
     }
@@ -224,6 +224,6 @@ struct Node {
 
 impl Node {
     fn new(x: i32, y: i32) -> Node {
-        Node { x: x, y: y }
+        Node { x, y }
     }
 }


### PR DESCRIPTION
Fixes all Clippy lints, runs `cargo fmt` on everything, requires both on CI, and updates Cargo.lock which was incorrectly not updated with the aho corasick PR.