### PR TITLE
Fix clippy CI, format byond_fn

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           toolchain: stable
           command: clippy
-          args: --target i686-pc-windows-msvc --all-features -- -D warnings
+          args: --target i686-pc-windows-msvc --all-features --locked -- -D warnings
       - name: Rustfmt
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,10 +17,10 @@ jobs:
           target: i686-pc-windows-msvc
           components: rustfmt, clippy
       - name: Clippy (all features)
-        uses: actions-rs/clippy-check@v1
+        uses: actions-rs/cargo@v1
         with:
           toolchain: stable
-          token: ${{ secrets.GITHUB_TOKEN }}
+          command: clippy
           args: --target i686-pc-windows-msvc --all-features -- -D warnings
       - name: Rustfmt
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +220,16 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "combine"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b2f5d0ee456f3928812dfc8c6d9a1d592b98678f6d56db9b0cd2b7bc6c8db5"
+dependencies = [
+ "bytes 1.0.1",
+ "memchr",
+]
 
 [[package]]
 name = "const-random"
@@ -382,6 +403,12 @@ name = "dmsort"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4699f5cb7678f099b747ffdc1e6ce6cdc42579e29d28315aa715b9fd10324fc"
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -1416,6 +1443,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f23ceed4c0e76b322657c2c3352ea116f9ec60a1a1aefeb3c84ed062c50865b"
+dependencies = [
+ "async-trait",
+ "combine",
+ "dtoa",
+ "itoa",
+ "percent-encoding",
+ "sha1",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1564,7 @@ dependencies = [
  "percent-encoding",
  "png",
  "rand 0.8.4",
+ "redis",
  "reqwest",
  "serde",
  "serde_json",

--- a/src/acreplace.rs
+++ b/src/acreplace.rs
@@ -53,7 +53,7 @@ thread_local! {
     static CREPLACE_MAP: RefCell<HashMap<String, Replacements>> = RefCell::new(HashMap::new());
 }
 
-byond_fn! { setup_acreplace(key, patterns_json, replacements_json) {
+byond_fn!(fn setup_acreplace(key, patterns_json, replacements_json) {
     let patterns: Vec<String> = serde_json::from_str(patterns_json).ok()?;
     let replacements: Vec<String> = serde_json::from_str(replacements_json).ok()?;
     let ac = AhoCorasickBuilder::new().auto_configure(&patterns).build(&patterns);
@@ -62,9 +62,9 @@ byond_fn! { setup_acreplace(key, patterns_json, replacements_json) {
         map.insert(key.to_owned(), Replacements { automaton: ac, replacements });
     });
     Some("")
-} }
+} );
 
-byond_fn! { setup_acreplace_with_options(key, options_json, patterns_json, replacements_json) {
+byond_fn!(fn setup_acreplace_with_options(key, options_json, patterns_json, replacements_json) {
     let options: AhoCorasickOptions = serde_json::from_str(options_json).ok()?;
     let patterns: Vec<String> = serde_json::from_str(patterns_json).ok()?;
     let replacements: Vec<String> = serde_json::from_str(replacements_json).ok()?;
@@ -74,21 +74,21 @@ byond_fn! { setup_acreplace_with_options(key, options_json, patterns_json, repla
         map.insert(key.to_owned(), Replacements { automaton: ac, replacements });
     });
     Some("")
-} }
+} );
 
-byond_fn! { acreplace(key, text) {
+byond_fn!(fn acreplace(key, text) {
     CREPLACE_MAP.with(|cell| -> Option<String> {
         let map = cell.borrow_mut();
         let replacements = map.get(key)?;
         Some(replacements.automaton.replace_all(text, &replacements.replacements))
     })
-} }
+} );
 
-byond_fn! { acreplace_with_replacements(key, text, replacements_json) {
+byond_fn!(fn acreplace_with_replacements(key, text, replacements_json) {
     let call_replacements: Vec<String> = serde_json::from_str(replacements_json).ok()?;
     CREPLACE_MAP.with(|cell| -> Option<String> {
         let map = cell.borrow_mut();
         let replacements = map.get(key)?;
         Some(replacements.automaton.replace_all(text, &call_replacements))
     })
-}}
+});

--- a/src/acreplace.rs
+++ b/src/acreplace.rs
@@ -62,7 +62,7 @@ byond_fn!(fn setup_acreplace(key, patterns_json, replacements_json) {
         map.insert(key.to_owned(), Replacements { automaton: ac, replacements });
     });
     Some("")
-} );
+});
 
 byond_fn!(fn setup_acreplace_with_options(key, options_json, patterns_json, replacements_json) {
     let options: AhoCorasickOptions = serde_json::from_str(options_json).ok()?;
@@ -74,7 +74,7 @@ byond_fn!(fn setup_acreplace_with_options(key, options_json, patterns_json, repl
         map.insert(key.to_owned(), Replacements { automaton: ac, replacements });
     });
     Some("")
-} );
+});
 
 byond_fn!(fn acreplace(key, text) {
     CREPLACE_MAP.with(|cell| -> Option<String> {
@@ -82,7 +82,7 @@ byond_fn!(fn acreplace(key, text) {
         let replacements = map.get(key)?;
         Some(replacements.automaton.replace_all(text, &replacements.replacements))
     })
-} );
+});
 
 byond_fn!(fn acreplace_with_replacements(key, text, replacements_json) {
     let call_replacements: Vec<String> = serde_json::from_str(replacements_json).ok()?;

--- a/src/byond.rs
+++ b/src/byond.rs
@@ -78,8 +78,9 @@ macro_rules! byond_fn {
     };
 }
 
+// Easy version checker. It's in this file so it is always included
 byond_fn!(
     fn get_version() {
         Some(env!("CARGO_PKG_VERSION"))
     }
-); // Easy version checker. It's in this file so it is always included
+);

--- a/src/byond.rs
+++ b/src/byond.rs
@@ -44,7 +44,7 @@ pub fn byond_return(value: Option<Vec<u8>>) -> *const c_char {
 
 #[macro_export]
 macro_rules! byond_fn {
-    ($name:ident() $body:block) => {
+    (fn $name:ident() $body:block) => {
         #[no_mangle]
         #[allow(clippy::missing_safety_doc)]
         pub unsafe extern "C" fn $name(
@@ -55,7 +55,7 @@ macro_rules! byond_fn {
         }
     };
 
-    ($name:ident($($arg:ident),* $(, ...$rest:ident)?) $body:block) => {
+    (fn $name:ident($($arg:ident),* $(, ...$rest:ident)?) $body:block) => {
         #[no_mangle]
         #[allow(clippy::missing_safety_doc)]
         pub unsafe extern "C" fn $name(
@@ -78,7 +78,8 @@ macro_rules! byond_fn {
     };
 }
 
-// Easy version checker. It's in this file so it is always included
-byond_fn! { get_version() {
-    Some(env!("CARGO_PKG_VERSION"))
-} }
+byond_fn!(
+    fn get_version() {
+        Some(env!("CARGO_PKG_VERSION"))
+    }
+); // Easy version checker. It's in this file so it is always included

--- a/src/cellularnoise.rs
+++ b/src/cellularnoise.rs
@@ -4,7 +4,7 @@ use std::fmt::Write;
 
 byond_fn!(fn cnoise_generate(percentage, smoothing_iterations, birth_limit, death_limit, width, height) {
     noise_gen(percentage, smoothing_iterations, birth_limit, death_limit, width, height).ok()
-} );
+});
 
 fn noise_gen(
     percentage_as_str: &str,

--- a/src/cellularnoise.rs
+++ b/src/cellularnoise.rs
@@ -2,9 +2,9 @@ use crate::error::Result;
 use rand::*;
 use std::fmt::Write;
 
-byond_fn! { cnoise_generate(percentage, smoothing_iterations, birth_limit, death_limit, width, height) {
+byond_fn!(fn cnoise_generate(percentage, smoothing_iterations, birth_limit, death_limit, width, height) {
     noise_gen(percentage, smoothing_iterations, birth_limit, death_limit, width, height).ok()
-} }
+} );
 
 fn noise_gen(
     percentage_as_str: &str,

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -7,11 +7,11 @@ use std::{
 
 byond_fn!(fn dmi_strip_metadata(path) {
     strip_metadata(path).err()
-} );
+});
 
 byond_fn!(fn dmi_create_png(path, width, height, data) {
     create_png(path, width, height, data).err()
-} );
+});
 
 byond_fn!(fn dmi_resize_png(path, width, height, resizetype) {
     let resizetype = match resizetype {
@@ -23,7 +23,7 @@ byond_fn!(fn dmi_resize_png(path, width, height, resizetype) {
         _ => image::imageops::Nearest,
     };
     resize_png(path, width, height, resizetype).err()
-} );
+});
 
 fn strip_metadata(path: &str) -> Result<()> {
     let (info, image) = read_png(path)?;

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -5,15 +5,15 @@ use std::{
     path::Path,
 };
 
-byond_fn! { dmi_strip_metadata(path) {
+byond_fn!(fn dmi_strip_metadata(path) {
     strip_metadata(path).err()
-} }
+} );
 
-byond_fn! { dmi_create_png(path, width, height, data) {
+byond_fn!(fn dmi_create_png(path, width, height, data) {
     create_png(path, width, height, data).err()
-} }
+} );
 
-byond_fn! { dmi_resize_png(path, width, height, resizetype) {
+byond_fn!(fn dmi_resize_png(path, width, height, resizetype) {
     let resizetype = match resizetype {
         "catmull" => image::imageops::CatmullRom,
         "gaussian" => image::imageops::Gaussian,
@@ -23,7 +23,7 @@ byond_fn! { dmi_resize_png(path, width, height, resizetype) {
         _ => image::imageops::Nearest,
     };
     resize_png(path, width, height, resizetype).err()
-} }
+} );
 
 fn strip_metadata(path: &str) -> Result<()> {
     let (info, image) = read_png(path)?;

--- a/src/file.rs
+++ b/src/file.rs
@@ -6,19 +6,19 @@ use std::{
 
 byond_fn!(fn file_read(path) {
     read(path).ok()
-} );
+});
 
 byond_fn!(fn file_exists(path) {
     Some(exists(path))
-} );
+});
 
 byond_fn!(fn file_write(data, path) {
     write(data, path).err()
-} );
+});
 
 byond_fn!(fn file_append(data, path) {
     append(data, path).err()
-} );
+});
 
 fn read(path: &str) -> Result<String> {
     let file = File::open(path)?;

--- a/src/file.rs
+++ b/src/file.rs
@@ -4,21 +4,21 @@ use std::{
     io::{BufReader, BufWriter, Read, Write},
 };
 
-byond_fn! { file_read(path) {
+byond_fn!(fn file_read(path) {
     read(path).ok()
-} }
+} );
 
-byond_fn! { file_exists(path) {
+byond_fn!(fn file_exists(path) {
     Some(exists(path))
-} }
+} );
 
-byond_fn! { file_write(data, path) {
+byond_fn!(fn file_write(data, path) {
     write(data, path).err()
-} }
+} );
 
-byond_fn! { file_append(data, path) {
+byond_fn!(fn file_append(data, path) {
     append(data, path).err()
-} }
+} );
 
 fn read(path: &str) -> Result<String> {
     let file = File::open(path)?;

--- a/src/git.rs
+++ b/src/git.rs
@@ -11,7 +11,7 @@ byond_fn!(fn rg_git_revparse(rev) {
         let object = repo.revparse_single(rev).map_err(|e| e.code())?;
         Ok(object.id().to_string())
     }).ok()
-} );
+});
 
 byond_fn!(fn rg_git_commit_date(rev) {
     REPOSITORY.with(|repo| -> Result<String, ErrorCode> {
@@ -21,4 +21,4 @@ byond_fn!(fn rg_git_commit_date(rev) {
         let datetime = Utc.timestamp(commit.time().seconds(), 0);
         Ok(datetime.format("%F").to_string())
     }).ok()
-} );
+});

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,15 +5,15 @@ thread_local! {
     static REPOSITORY: Result<Repository, Error> = Repository::open(".");
 }
 
-byond_fn! { rg_git_revparse(rev) {
+byond_fn!(fn rg_git_revparse(rev) {
     REPOSITORY.with(|repo| -> Result<String, ErrorCode> {
         let repo = repo.as_ref().map_err(Error::code)?;
         let object = repo.revparse_single(rev).map_err(|e| e.code())?;
         Ok(object.id().to_string())
     }).ok()
-} }
+} );
 
-byond_fn! { rg_git_commit_date(rev) {
+byond_fn!(fn rg_git_commit_date(rev) {
     REPOSITORY.with(|repo| -> Result<String, ErrorCode> {
         let repo = repo.as_ref().map_err(Error::code)?;
         let object = repo.revparse_single(rev).map_err(|e| e.code())?;
@@ -21,4 +21,4 @@ byond_fn! { rg_git_commit_date(rev) {
         let datetime = Utc.timestamp(commit.time().seconds(), 0);
         Ok(datetime.format("%F").to_string())
     }).ok()
-} }
+} );

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -13,22 +13,22 @@ use std::{
 };
 use twox_hash::XxHash64;
 
-byond_fn! { hash_string(algorithm, string) {
+byond_fn!(fn hash_string(algorithm, string) {
     string_hash(algorithm, string).ok()
-} }
+});
 
-byond_fn! { hash_file(algorithm, string) {
+byond_fn!(fn hash_file(algorithm, string) {
     file_hash(algorithm, string).ok()
-} }
+});
 
-byond_fn! { generate_totp(hex_seed) {
+byond_fn!(fn generate_totp(hex_seed) {
     match totp_generate(hex_seed, 0, None) {
         Ok(value) => Some(value),
         Err(error) => return Some(format!("ERROR: {:?}", error))
     }
-} }
+});
 
-byond_fn! { generate_totp_tolerance(hex_seed, tolerance) {
+byond_fn!(fn generate_totp_tolerance(hex_seed, tolerance) {
     let tolerance_value: i32 = match tolerance.parse() {
         Ok(value) => value,
         Err(_) => return Some(String::from("ERROR: Tolerance not a valid integer"))
@@ -37,7 +37,7 @@ byond_fn! { generate_totp_tolerance(hex_seed, tolerance) {
         Ok(value) => Some(value),
         Err(error) => return Some(format!("ERROR: {:?}", error))
     }
-} }
+});
 
 fn hash_algorithm<B: AsRef<[u8]>>(name: &str, bytes: B) -> Result<String> {
     match name {

--- a/src/http.rs
+++ b/src/http.rs
@@ -22,7 +22,7 @@ struct Response<'a> {
 
 // If the response can be deserialized -> success.
 // If the response can't be deserialized -> failure.
-byond_fn! { http_request_blocking(method, url, body, headers, ...rest) {
+byond_fn!(fn http_request_blocking(method, url, body, headers, ...rest) {
     let req = match construct_request(method, url, body, headers, rest.first().map(|x| &**x)) {
         Ok(r) => r,
         Err(e) => return Some(e.to_string())
@@ -32,10 +32,10 @@ byond_fn! { http_request_blocking(method, url, body, headers, ...rest) {
         Ok(r) => Some(r),
         Err(e) => Some(e.to_string())
     }
-} }
+} );
 
 // Returns new job-id.
-byond_fn! { http_request_async(method, url, body, headers, ...rest) {
+byond_fn!(fn http_request_async(method, url, body, headers, ...rest) {
     let req = match construct_request(method, url, body, headers, rest.first().map(|x| &**x)) {
         Ok(r) => r,
         Err(e) => return Some(e.to_string())
@@ -47,13 +47,13 @@ byond_fn! { http_request_async(method, url, body, headers, ...rest) {
             Err(e) => e.to_string()
         }
     }))
-} }
+} );
 
 // If the response can be deserialized -> success.
 // If the response can't be deserialized -> failure or WIP.
-byond_fn! { http_check_request(id) {
+byond_fn!(fn http_check_request(id) {
     Some(jobs::check(id))
-} }
+} );
 
 // ----------------------------------------------------------------------------
 // Shared HTTP client state

--- a/src/http.rs
+++ b/src/http.rs
@@ -32,7 +32,7 @@ byond_fn!(fn http_request_blocking(method, url, body, headers, ...rest) {
         Ok(r) => Some(r),
         Err(e) => Some(e.to_string())
     }
-} );
+});
 
 // Returns new job-id.
 byond_fn!(fn http_request_async(method, url, body, headers, ...rest) {
@@ -47,13 +47,13 @@ byond_fn!(fn http_request_async(method, url, body, headers, ...rest) {
             Err(e) => e.to_string()
         }
     }))
-} );
+});
 
 // If the response can be deserialized -> success.
 // If the response can't be deserialized -> failure or WIP.
 byond_fn!(fn http_check_request(id) {
     Some(jobs::check(id))
-} );
+});
 
 // ----------------------------------------------------------------------------
 // Shared HTTP client state

--- a/src/json.rs
+++ b/src/json.rs
@@ -3,14 +3,14 @@ use std::cmp;
 
 const VALID_JSON_MAX_RECURSION_DEPTH: usize = 8;
 
-byond_fn! { json_is_valid(text) {
+byond_fn!(fn json_is_valid(text) {
     let value = match serde_json::from_str::<Value>(text) {
         Ok(value) => value,
         Err(_) => return Some("false".to_owned())
     };
 
     Some(get_recursion_level(&value).is_ok().to_string())
-} }
+} );
 
 /// Gets the recursion level of the given value
 /// If it is above VALID_JSON_MAX_RECURSION_DEPTH, returns Err(())

--- a/src/json.rs
+++ b/src/json.rs
@@ -10,7 +10,7 @@ byond_fn!(fn json_is_valid(text) {
     };
 
     Some(get_recursion_level(&value).is_ok().to_string())
-} );
+});
 
 /// Gets the recursion level of the given value
 /// If it is above VALID_JSON_MAX_RECURSION_DEPTH, returns Err(())

--- a/src/log.rs
+++ b/src/log.rs
@@ -42,7 +42,7 @@ byond_fn!(fn log_write(path, data, ...rest) {
 
         Ok(())
     }).err()
-} );
+});
 
 byond_fn!(
     fn log_close_all() {

--- a/src/log.rs
+++ b/src/log.rs
@@ -14,7 +14,7 @@ thread_local! {
     static FILE_MAP: RefCell<HashMap<OsString, File>> = RefCell::new(HashMap::new());
 }
 
-byond_fn! { log_write(path, data, ...rest) {
+byond_fn!(fn log_write(path, data, ...rest) {
     FILE_MAP.with(|cell| -> Result<()> {
         // open file
         let mut map = cell.borrow_mut();
@@ -42,15 +42,17 @@ byond_fn! { log_write(path, data, ...rest) {
 
         Ok(())
     }).err()
-} }
+} );
 
-byond_fn! { log_close_all() {
-    FILE_MAP.with(|cell| {
-        let mut map = cell.borrow_mut();
-        map.clear();
-    });
-    Some("")
-} }
+byond_fn!(
+    fn log_close_all() {
+        FILE_MAP.with(|cell| {
+            let mut map = cell.borrow_mut();
+            map.clear();
+        });
+        Some("")
+    }
+);
 
 fn open(path: &Path) -> Result<File> {
     if let Some(parent) = path.parent() {

--- a/src/noise_gen.rs
+++ b/src/noise_gen.rs
@@ -10,9 +10,9 @@ thread_local! {
     static GENERATORS: RefCell<HashMap<String,  Perlin>> = RefCell::new(HashMap::new());
 }
 
-byond_fn! { noise_get_at_coordinates(seed, x, y) {
+byond_fn!(fn noise_get_at_coordinates(seed, x, y) {
     get_at_coordinates(seed, x, y).ok()
-} }
+} );
 
 //note that this will be 0 at integer x & y, scaling is left up to the caller
 fn get_at_coordinates(seed_as_str: &str, x_as_str: &str, y_as_str: &str) -> Result<String> {

--- a/src/noise_gen.rs
+++ b/src/noise_gen.rs
@@ -12,7 +12,7 @@ thread_local! {
 
 byond_fn!(fn noise_get_at_coordinates(seed, x, y) {
     get_at_coordinates(seed, x, y).ok()
-} );
+});
 
 //note that this will be 0 at integer x & y, scaling is left up to the caller
 fn get_at_coordinates(seed_as_str: &str, x_as_str: &str, y_as_str: &str) -> Result<String> {

--- a/src/redis_pubsub.rs
+++ b/src/redis_pubsub.rs
@@ -152,23 +152,27 @@ fn get_messages() -> String {
     serde_json::to_string(&result).unwrap_or("{}".to_owned())
 }
 
-byond_fn! { redis_connect(addr) {
+byond_fn!(fn redis_connect(addr) {
     connect(addr).err().map(|e| e.to_string())
-} }
+});
 
-byond_fn! { redis_disconnect() {
-    disconnect();
-    Some("")
-} }
+byond_fn!(
+    fn redis_disconnect() {
+        disconnect();
+        Some("")
+    }
+);
 
-byond_fn! { redis_subscribe(channel) {
+byond_fn!(fn redis_subscribe(channel) {
     subscribe(channel)
-} }
+});
 
-byond_fn! { redis_get_messages() {
-    Some(get_messages())
-} }
+byond_fn!(
+    fn redis_get_messages() {
+        Some(get_messages())
+    }
+);
 
-byond_fn! { redis_publish(channel, message) {
+byond_fn!(fn redis_publish(channel, message) {
     publish(channel, message)
-} }
+});

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -32,7 +32,7 @@ struct ConnectOptions {
     max_threads: Option<usize>,
 }
 
-byond_fn! { sql_connect_pool(options) {
+byond_fn!(fn sql_connect_pool(options) {
     let options = match serde_json::from_str::<ConnectOptions>(options) {
         Ok(options) => options,
         Err(e) => return Some(err_to_json(e)),
@@ -41,16 +41,16 @@ byond_fn! { sql_connect_pool(options) {
         Ok(o) => o.to_string(),
         Err(e) => err_to_json(e)
     })
-} }
+} );
 
-byond_fn! { sql_query_blocking(handle, query, params) {
+byond_fn!(fn sql_query_blocking(handle, query, params) {
     Some(match do_query(handle, query, params) {
         Ok(o) => o.to_string(),
         Err(e) => err_to_json(e)
     })
-} }
+} );
 
-byond_fn! { sql_query_async(handle, query, params) {
+byond_fn!(fn sql_query_async(handle, query, params) {
     let handle = handle.to_owned();
     let query = query.to_owned();
     let params = params.to_owned();
@@ -60,10 +60,10 @@ byond_fn! { sql_query_async(handle, query, params) {
             Err(e) => err_to_json(e)
         }
     }))
-} }
+} );
 
 // hopefully won't panic if queries are running
-byond_fn! { sql_disconnect_pool(handle) {
+byond_fn!(fn sql_disconnect_pool(handle) {
     let handle = match handle.parse::<usize>() {
         Ok(o) => o,
         Err(e) => return Some(err_to_json(e)),
@@ -80,9 +80,9 @@ byond_fn! { sql_disconnect_pool(handle) {
             }).to_string()
         }
     )
-} }
+} );
 
-byond_fn! { sql_connected(handle) {
+byond_fn!(fn sql_connected(handle) {
     let handle = match handle.parse::<usize>() {
         Ok(o) => o,
         Err(e) => return Some(err_to_json(e)),
@@ -97,11 +97,11 @@ byond_fn! { sql_connected(handle) {
             }).to_string()
         }
     )
-} }
+} );
 
-byond_fn! { sql_check_query(id) {
+byond_fn!(fn sql_check_query(id) {
     Some(jobs::check(id))
-} }
+} );
 
 // ----------------------------------------------------------------------------
 // Main connect and query implementation

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -41,14 +41,14 @@ byond_fn!(fn sql_connect_pool(options) {
         Ok(o) => o.to_string(),
         Err(e) => err_to_json(e)
     })
-} );
+});
 
 byond_fn!(fn sql_query_blocking(handle, query, params) {
     Some(match do_query(handle, query, params) {
         Ok(o) => o.to_string(),
         Err(e) => err_to_json(e)
     })
-} );
+});
 
 byond_fn!(fn sql_query_async(handle, query, params) {
     let handle = handle.to_owned();
@@ -60,7 +60,7 @@ byond_fn!(fn sql_query_async(handle, query, params) {
             Err(e) => err_to_json(e)
         }
     }))
-} );
+});
 
 // hopefully won't panic if queries are running
 byond_fn!(fn sql_disconnect_pool(handle) {
@@ -80,7 +80,7 @@ byond_fn!(fn sql_disconnect_pool(handle) {
             }).to_string()
         }
     )
-} );
+});
 
 byond_fn!(fn sql_connected(handle) {
     let handle = match handle.parse::<usize>() {
@@ -97,11 +97,11 @@ byond_fn!(fn sql_connected(handle) {
             }).to_string()
         }
     )
-} );
+});
 
 byond_fn!(fn sql_check_query(id) {
     Some(jobs::check(id))
-} );
+});
 
 // ----------------------------------------------------------------------------
 // Main connect and query implementation

--- a/src/time.rs
+++ b/src/time.rs
@@ -6,7 +6,7 @@ use std::{
 
 thread_local!( static INSTANTS: RefCell<HashMap<String, Instant>> = RefCell::new(HashMap::new()) );
 
-byond_fn! { time_microseconds(instant_id) {
+byond_fn!(fn time_microseconds(instant_id) {
     INSTANTS.with(|instants| {
         let mut map = instants.borrow_mut();
         let instant = match map.entry(instant_id.into()) {
@@ -15,9 +15,9 @@ byond_fn! { time_microseconds(instant_id) {
         };
         Some(instant.elapsed().as_micros().to_string())
     })
-} }
+} );
 
-byond_fn! { time_milliseconds(instant_id) {
+byond_fn!(fn time_milliseconds(instant_id) {
     INSTANTS.with(|instants| {
         let mut map = instants.borrow_mut();
         let instant = match map.entry(instant_id.into()) {
@@ -26,12 +26,12 @@ byond_fn! { time_milliseconds(instant_id) {
         };
         Some(instant.elapsed().as_millis().to_string())
     })
-} }
+} );
 
-byond_fn! { time_reset(instant_id) {
+byond_fn!(fn time_reset(instant_id) {
     INSTANTS.with(|instants| {
         let mut map = instants.borrow_mut();
         map.insert(instant_id.into(), Instant::now());
         Some("")
     })
-} }
+} );

--- a/src/time.rs
+++ b/src/time.rs
@@ -15,7 +15,7 @@ byond_fn!(fn time_microseconds(instant_id) {
         };
         Some(instant.elapsed().as_micros().to_string())
     })
-} );
+});
 
 byond_fn!(fn time_milliseconds(instant_id) {
     INSTANTS.with(|instants| {
@@ -26,7 +26,7 @@ byond_fn!(fn time_milliseconds(instant_id) {
         };
         Some(instant.elapsed().as_millis().to_string())
     })
-} );
+});
 
 byond_fn!(fn time_reset(instant_id) {
     INSTANTS.with(|instants| {
@@ -34,4 +34,4 @@ byond_fn!(fn time_reset(instant_id) {
         map.insert(instant_id.into(), Instant::now());
         Some("")
     })
-} );
+});

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -1,8 +1,8 @@
 use crate::error::Result;
 
-byond_fn! { toml_file_to_json(path) {
+byond_fn!(fn toml_file_to_json(path) {
     toml_file_to_json_impl(path).ok()
-} }
+} );
 
 fn toml_file_to_json_impl(path: &str) -> Result<String> {
     Ok(serde_json::to_string(&toml_dep::from_str::<

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -2,7 +2,7 @@ use crate::error::Result;
 
 byond_fn!(fn toml_file_to_json(path) {
     toml_file_to_json_impl(path).ok()
-} );
+});
 
 fn toml_file_to_json_impl(path: &str) -> Result<String> {
     Ok(serde_json::to_string(&toml_dep::from_str::<

--- a/src/unzip.rs
+++ b/src/unzip.rs
@@ -20,12 +20,12 @@ fn construct_unzip(url: &str, unzip_directory: &str) -> UnzipPrep {
     }
 }
 
-byond_fn! { unzip_download_async(url, unzip_directory) {
+byond_fn!(fn unzip_download_async(url, unzip_directory) {
     let unzip = construct_unzip(url, unzip_directory);
     Some(jobs::start(move ||
         do_unzip_download(unzip).unwrap_or_else(|e| e.to_string())
     ))
-} }
+});
 
 fn do_unzip_download(prep: UnzipPrep) -> Result<String> {
     let unzip_path = Path::new(&prep.unzip_directory);
@@ -58,6 +58,6 @@ fn do_unzip_download(prep: UnzipPrep) -> Result<String> {
     Ok("true".to_string())
 }
 
-byond_fn! { unzip_check(id) {
+byond_fn!(fn unzip_check(id) {
     Some(jobs::check(id))
-} }
+});

--- a/src/url.rs
+++ b/src/url.rs
@@ -4,11 +4,11 @@ use url_dep::form_urlencoded::byte_serialize;
 
 byond_fn!(fn url_encode(data) {
     Some(encode(data))
-} );
+});
 
 byond_fn!(fn url_decode(data) {
     decode(data).ok()
-} );
+});
 
 fn encode(string: &str) -> String {
     byte_serialize(string.as_bytes()).collect()

--- a/src/url.rs
+++ b/src/url.rs
@@ -2,13 +2,13 @@ use crate::error::Result;
 use std::borrow::Cow;
 use url_dep::form_urlencoded::byte_serialize;
 
-byond_fn! { url_encode(data) {
+byond_fn!(fn url_encode(data) {
     Some(encode(data))
-} }
+} );
 
-byond_fn! { url_decode(data) {
+byond_fn!(fn url_decode(data) {
     decode(data).ok()
-} }
+} );
 
 fn encode(string: &str) -> String {
     byte_serialize(string.as_bytes()).collect()

--- a/src/worleynoise.rs
+++ b/src/worleynoise.rs
@@ -3,9 +3,9 @@ use rand::*;
 use std::fmt::Write;
 use std::rc::Rc;
 
-byond_fn! { worley_generate(region_size, threshold, node_per_region_chance, width, height) {
+byond_fn!(fn worley_generate(region_size, threshold, node_per_region_chance, width, height) {
     worley_noise(region_size, threshold, node_per_region_chance, width, height).ok()
-} }
+});
 
 // This is a quite complex algorithm basically what it does is it creates 2 maps, one filled with cells and the other with 'regions' that map onto these cells.
 // Each region can spawn 1 node, the cell then determines wether it is true or false depending on the distance from it to the nearest node in the region minus the second closest node.


### PR DESCRIPTION
Changes action/clippy to just action/cargo so that we don't have to read awful JSON dumps.

Changes .editorconfig to LF mode, because VSC keeps changing it to CRLF, and I don't know why.

Changes `byond_fn!` from `byond_fn! { name() {} }` to `byond_fn!(fn name() {})` so that Rustfmt picks up on it.

Adds `--locked` to Clippy's CI so that we can make sure Cargo.lock is up to date.

Updates Cargo.lock because it kept doing it I guess.