### PR TITLE
Bump to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "rust-g"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aho-corasick",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-g"
 edition = "2018"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Bjorn Neergaard <bjorn@neersighted.com>"]
 repository = "https://github.com/tgstation/rust-g"
 license-file = "LICENSE"


### PR DESCRIPTION
Changes since last release:
- Added TOTP generation on hash feature (#76)
- Added Precise time measurement (#77)
- Added Aho-Corasick string replacements (#82)
- Added Redis Pub/Sub integration (#80)
- Other optimisations

WIll create release with this text & artefacts from the CI run 