### PR TITLE
Add functions for seeking lines and getting line counts in functions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,7 @@ fn main() {
     for (key, _value) in std::env::vars() {
         // CARGO_FEATURE_<name> — For each activated feature of the package being built, this environment variable will be present where <name> is the name of the feature uppercased and having - translated to _.
         if let Some(uprfeature) = key.strip_prefix("CARGO_FEATURE_") {
-            let feature = uprfeature.to_lowercase().replace("_", "-"); // actual proper name of the enabled feature
+            let feature = uprfeature.to_lowercase().replace('_', "-"); // actual proper name of the enabled feature
             if feature_dm_exists!(&feature) {
                 writeln!(
                     f,

--- a/dmsrc/file.dm
+++ b/dmsrc/file.dm
@@ -2,6 +2,8 @@
 #define rustg_file_exists(fname) call(RUST_G, "file_exists")(fname)
 #define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, fname)
 #define rustg_file_append(text, fname) call(RUST_G, "file_append")(text, fname)
+#define rustg_file_get_line_count(fname) text2num(call(RUST_G, "file_get_line_count")(fname))
+#define rustg_file_seek_line(fname, line) call(RUST_G, "file_seek_line")(fname, "[line]")
 
 #ifdef RUSTG_OVERRIDE_BUILTINS
 	#define file2text(fname) rustg_file_read("[fname]")


### PR DESCRIPTION
Adds `rustg_file_get_line_count` for getting the line count of a given filename, and `rustg_file_seek_line` for getting a specific line.

These are useful as to not load the entire file into memory in DM, which is useful for very large files like dictionaries.