### PR TITLE
toml to json now returns error reasons to byond + rust-analyzer.cargo.target gnu > msvc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "rust-analyzer.cargo.target": "i686-pc-windows-gnu"
+    "rust-analyzer.cargo.target": "i686-pc-windows-msvc"
 }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ System libraries:
 
 * Other Linux distributions install the appropriate **32-bit development** and **32-bit runtime** packages.
 
+If you want to use the `pc-windows-gnu` or similar other target ABI, do the following:
+1. Change the `"rust-analyzer.cargo.target"` setting in `.cargo/config` to `i686-pc-windows-gnu`.
+2. Run `git update-index --assume-unchanged .cargo/config`, which will tell git to 'ignore' the changes you made.
+3. If you find yourself ever wanting to change back, run `git update-index --no-assume-unchanged .cargo/config`.
+
 ## Compiling
 
 The [Cargo] tool handles compilation, as well as automatically downloading and

--- a/dmsrc/toml.dm
+++ b/dmsrc/toml.dm
@@ -1,1 +1,8 @@
-#define rustg_read_toml_file(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+#define rustg_raw_read_toml_file(path) json_decode(call(RUST_G, "toml_file_to_json")(path) || "null")
+
+/proc/rustg_read_toml_file(path)
+	var/list/output = rustg_raw_read_toml_file(path)
+	if (output["success"])
+		return output["content"]
+	else
+		CRASH(output["content"])

--- a/src/toml.rs
+++ b/src/toml.rs
@@ -1,7 +1,16 @@
 use crate::error::Result;
 
 byond_fn!(fn toml_file_to_json(path) {
-    toml_file_to_json_impl(path).ok()
+    serde_json::to_string(
+        &match toml_file_to_json_impl(path) {
+            Ok(value) => serde_json::json!({
+                "success": true, "content": value
+            }),
+            Err(error) => serde_json::json!({
+                "success": false, "content": error.to_string()
+            }),
+        }
+    ).ok()
 });
 
 fn toml_file_to_json_impl(path: &str) -> Result<String> {

--- a/tests/abc-tests.rs
+++ b/tests/abc-tests.rs
@@ -6,7 +6,7 @@ fn are_captures_sorted(matches: CaptureMatches, context: &str) -> Result<(), Str
     let mut prev_string = "";
     for cap in matches {
         let capstring = cap.get(0).unwrap().as_str();
-        match prev_string.cmp(&capstring) {
+        match prev_string.cmp(capstring) {
             Ordering::Greater => {
                 return Err(format!("{} is not sorted in {}", &capstring, &context))
             }

--- a/tests/dm/toml.dme
+++ b/tests/dm/toml.dme
@@ -17,5 +17,5 @@ var/test_json = @{"
 
     var/toml_output = rustg_read_toml_file("test.toml")
 
-    if (toml_output != test_output)
+    if (toml_output != test_json)
         CRASH("test:\n[test_toml]\n \nexpected:\n[test_json]\n \nrustg:\n[toml_output]")

--- a/tests/dm/toml.dme
+++ b/tests/dm/toml.dme
@@ -18,6 +18,5 @@ var/test_json = @{"
     var/toml_output = json_encode(rustg_read_toml_file("test.toml"))
     var/test_output = json_encode(json_decode(test_json)) // Double-encode so true becomes 1
 
-    // ~= checks for structural equality
-    if (toml_output["content"] != test_output)
+    if (toml_output != test_output)
         CRASH("test:\n[test_toml]\n \nexpected:\n[test_output]\n \nrustg:\n[toml_output]")

--- a/tests/dm/toml.dme
+++ b/tests/dm/toml.dme
@@ -19,5 +19,5 @@ var/test_json = @{"
     var/test_output = json_encode(json_decode(test_json)) // Double-encode so true becomes 1
 
     // ~= checks for structural equality
-    if (toml_output != test_output)
+    if (toml_output["content"] != test_output)
         CRASH("test:\n[test_toml]\n \nexpected:\n[test_output]\n \nrustg:\n[toml_output]")

--- a/tests/dm/toml.dme
+++ b/tests/dm/toml.dme
@@ -15,8 +15,7 @@ var/test_json = @{"
 /test/proc/check_toml_file2json()
     rustg_file_write(test_toml, "test.toml")
 
-    var/toml_output = json_encode(rustg_read_toml_file("test.toml"))
-    var/test_output = json_encode(json_decode(test_json)) // Double-encode so true becomes 1
+    var/toml_output = rustg_read_toml_file("test.toml")
 
     if (toml_output != test_output)
-        CRASH("test:\n[test_toml]\n \nexpected:\n[test_output]\n \nrustg:\n[toml_output]")
+        CRASH("test:\n[test_toml]\n \nexpected:\n[test_json]\n \nrustg:\n[toml_output]")


### PR DESCRIPTION
toml to json: One half of better error reporting for things like banned word filters in game, the other half has to be displaying the error on DM side.

rust-analyzer.cargo.target: fixes #86 and let me say holy shit that was one hellish part of getting the analyzer working

![BLAZING](https://forthebadge.com/images/badges/made-with-rust.svg)
![LY FAST](https://cdn.discordapp.com/attachments/590280000977240105/981756738472652810/holy-shit-fuck-your-settings.json.png)