### PR TITLE
Adds a new type of noise: Discrete Batched Perlin-like Noise (DBP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbpnoise"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a92e2d3660e5513454071018433d22bbdfc8a79b9bcf1b6399aa72e96b8586"
+dependencies = [
+ "lerp",
+ "rand 0.8.5",
+ "rand_pcg",
+ "rand_seeder",
+ "rayon",
+]
+
+[[package]]
 name = "deflate"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +844,15 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lerp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b19ac50d419bff1a024a8eb8034bfbee6c1cf8fa3472502f6bd3def327b09e4c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "lexical"
@@ -1337,19 +1359,18 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -1400,10 +1421,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
+name = "rand_pcg"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_seeder"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2890aaef0aa82719a50e808de264f9484b74b442e1a3a0e5ee38243ac40bdb"
 dependencies = [
  "rand_core 0.6.3",
 ]
@@ -1419,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -1431,14 +1461,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -1544,13 +1573,14 @@ dependencies = [
 
 [[package]]
 name = "rust-g"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aho-corasick",
  "base64 0.13.0",
  "chrono",
  "const-random",
  "dashmap",
+ "dbpnoise",
  "dmsort",
  "flume",
  "git2",
@@ -1563,7 +1593,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "png",
- "rand 0.8.4",
+ "rand 0.8.5",
  "redis",
  "regex",
  "reqwest",
@@ -1899,7 +1929,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
- "rand 0.8.4",
+ "rand 0.8.5",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -2097,7 +2127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
  "cfg-if",
- "rand 0.8.4",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ aho-corasick = { version = "0.7.18", optional = true}
 dbpnoise = { version = "0.1.2", optional = true}
 
 [features]
-default = ["acreplace", "cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "time", "toml", "url", "batchnoise"]
+default = ["acreplace", "cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "time", "toml", "url"]
 
 # default features
 acreplace = ["aho-corasick"]
@@ -63,13 +63,13 @@ sql = ["mysql", "serde", "serde_json", "once_cell", "dashmap", "jobs"]
 time = []
 toml = ["serde", "serde_json", "toml-dep"]
 url = ["url-dep", "percent-encoding"]
-batchnoise = ["dbpnoise"]
 
 # additional features
 hash = ["base64", "const-random", "md-5", "hex", "sha-1", "sha2",  "twox-hash", "serde", "serde_json"]
 redis_pubsub = ["flume", "redis", "serde", "serde_json"]
 unzip = ["zip", "jobs"]
 worleynoise = ["rand","dmsort"]
+batchnoise = ["dbpnoise"]
 
 # internal feature-like things
 jobs = ["flume"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-g"
 edition = "2018"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Bjorn Neergaard <bjorn@neersighted.com>"]
 repository = "https://github.com/tgstation/rust-g"
 license-file = "LICENSE"
@@ -45,9 +45,10 @@ rand = {version = "0.8", optional = true}
 dmsort = {version = "1.0.0", optional = true }
 toml-dep = { version = "0.5.8", package="toml", optional = true }
 aho-corasick = { version = "0.7.18", optional = true}
+dbpnoise = { version = "0.1.2", optional = true}
 
 [features]
-default = ["acreplace", "cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "time", "toml", "url"]
+default = ["acreplace", "cellularnoise", "dmi", "file", "git", "http", "json", "log", "noise", "sql", "time", "toml", "url", "batchnoise"]
 
 # default features
 acreplace = ["aho-corasick"]
@@ -62,6 +63,7 @@ sql = ["mysql", "serde", "serde_json", "once_cell", "dashmap", "jobs"]
 time = []
 toml = ["serde", "serde_json", "toml-dep"]
 url = ["url-dep", "percent-encoding"]
+batchnoise = ["dbpnoise"]
 
 # additional features
 hash = ["base64", "const-random", "md-5", "hex", "sha-1", "sha2",  "twox-hash", "serde", "serde_json"]

--- a/dmsrc/dbpnoise.dm
+++ b/dmsrc/dbpnoise.dm
@@ -1,0 +1,16 @@
+/**
+ * This proc generates a grid of perlin-like noise
+ *
+ * Returns a single string that goes row by row, with values of 1 representing an turned on cell, and a value of 0 representing a turned off cell.
+ *
+ * Arguments:
+ * * seed: seed for the function
+ * * accuracy: how close this is to the original perlin noise, as accuracy approaches infinity, the noise becomes more and more perlin-like
+ * * stamp_size: Size of a singular stamp used by the algorithm, think of this as the same stuff as frequency in perlin noise
+ * * world_size: size of the returned grid.
+ * * lower_range: lower bound of values selected for. (inclusive)
+ * * upper_range: upper bound of values selected for. (exclusive)
+ */
+#define rustg_dbp_generate(seed, accuracy, stamp_size, world_size, lower_range, upper_range) \
+	call(RUST_G, "dbp_generate")(seed, accuracy, stamp_size, world_size, lower_range, upper_range)
+

--- a/src/dbpnoise.rs
+++ b/src/dbpnoise.rs
@@ -1,0 +1,22 @@
+use dbpnoise::gen_noise;
+use crate::error::Result;
+
+byond_fn!(fn dbp_generate(seed, accuracy, stamp_size, world_size, lower_range, upper_range) {
+    gen_dbp_noise(seed, accuracy, stamp_size, world_size, lower_range, upper_range).ok()
+});
+
+fn gen_dbp_noise(seed: &str, accuracy_as_str: &str, stamp_size_as_str: &str, world_size_as_str: &str, lower_range_as_str: &str, upper_range_as_str: &str) -> Result<String> {
+    let accuracy = accuracy_as_str.parse::<usize>()?;
+    let stamp_size = stamp_size_as_str.parse::<usize>()?;
+    let world_size = world_size_as_str.parse::<usize>()?;
+    let lower_range = lower_range_as_str.parse::<f32>()?;
+    let upper_range = upper_range_as_str.parse::<f32>()?;
+    let map: Vec<Vec<bool>> = gen_noise(seed, accuracy, stamp_size, world_size, lower_range, upper_range);
+    let mut result = String::new();
+    for row in map {
+        for cell in row {
+            result.push(if cell { '1' } else { '0' });
+        }
+    }
+    Ok(result)
+}

--- a/src/dbpnoise.rs
+++ b/src/dbpnoise.rs
@@ -1,17 +1,31 @@
-use dbpnoise::gen_noise;
 use crate::error::Result;
+use dbpnoise::gen_noise;
 
 byond_fn!(fn dbp_generate(seed, accuracy, stamp_size, world_size, lower_range, upper_range) {
     gen_dbp_noise(seed, accuracy, stamp_size, world_size, lower_range, upper_range).ok()
 });
 
-fn gen_dbp_noise(seed: &str, accuracy_as_str: &str, stamp_size_as_str: &str, world_size_as_str: &str, lower_range_as_str: &str, upper_range_as_str: &str) -> Result<String> {
+fn gen_dbp_noise(
+    seed: &str,
+    accuracy_as_str: &str,
+    stamp_size_as_str: &str,
+    world_size_as_str: &str,
+    lower_range_as_str: &str,
+    upper_range_as_str: &str,
+) -> Result<String> {
     let accuracy = accuracy_as_str.parse::<usize>()?;
     let stamp_size = stamp_size_as_str.parse::<usize>()?;
     let world_size = world_size_as_str.parse::<usize>()?;
     let lower_range = lower_range_as_str.parse::<f32>()?;
     let upper_range = upper_range_as_str.parse::<f32>()?;
-    let map: Vec<Vec<bool>> = gen_noise(seed, accuracy, stamp_size, world_size, lower_range, upper_range);
+    let map: Vec<Vec<bool>> = gen_noise(
+        seed,
+        accuracy,
+        stamp_size,
+        world_size,
+        lower_range,
+        upper_range,
+    );
     let mut result = String::new();
     for row in map {
         for cell in row {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,5 +43,8 @@ pub mod url;
 #[cfg(feature = "worleynoise")]
 pub mod worleynoise;
 
+#[cfg(feature = "dbpnoise")]
+pub mod dbpnoise;
+
 #[cfg(not(target_pointer_width = "32"))]
 compile_error!("rust-g must be compiled for a 32-bit target");


### PR DESCRIPTION
Hello!, I've recently been working on jungleland for yogstation, and i realized that calling current rust-g perlin noise255x255 per z level is **extremely** slow, so i coded this. DBP is a type of noise i recently coded and published to crates.io, so i decided to add it to rust-g. 
Here is the code to DBP https://github.com/EdgeLordExe/batch-perlin-like-noise-rs

DBP is extremely fucking fast, it's multithreaded and most importantly it allows byond to not waste time calling perlin noise like thousands of times, instead calling only once and recieveing the results in a single string (just how cellularnoise does it)

Some screenshots: 
![obraz](https://user-images.githubusercontent.com/42111655/173193310-8f01c7a5-6358-4011-8abb-6d96956ac974.png)
