### PR TITLE
Small improvements for before 1.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     env:
-      BYOND_MAJOR: 515
+      BYOND_MAJOR: 514
       BYOND_MINOR: 1585
       PKG_CONFIG_ALLOW_CROSS: 1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,62 +11,78 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: i686-pc-windows-msvc
           components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
       - name: Clippy (all features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: clippy
           args: --target i686-pc-windows-msvc --all-features --locked -- -D warnings
+
       - name: Rustfmt
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: fmt
           args: -- --check
+
       - name: Build (release) (default features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: build
           args: --target i686-pc-windows-msvc --release
+
       - uses: actions/upload-artifact@v1
         with:
           name: rust_g.dll
           path: target/i686-pc-windows-msvc/release/rust_g.dll
+
   build-linux:
     runs-on: ubuntu-latest
     env:
-      BYOND_MAJOR: 513
-      BYOND_MINOR: 1536
+      BYOND_MAJOR: 515
+      BYOND_MINOR: 1585
       PKG_CONFIG_ALLOW_CROSS: 1
+
     steps:
       - uses: actions/checkout@v1
+
       - run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
           sudo apt-get install g++-multilib zlib1g-dev:i386 libssl-dev:i386
           ./scripts/install_byond.sh
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: i686-unknown-linux-gnu
+
+      - uses: Swatinem/rust-cache@v2
+
       - name: Check (all features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: check
           args: --target i686-unknown-linux-gnu --all-features
+
       - name: Build (Debug) (all features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: build
           args: --target i686-unknown-linux-gnu --all-features
+
       - name: Run tests (all features)
         uses: actions-rs/cargo@v1
         with:
@@ -75,12 +91,14 @@ jobs:
           args: --target i686-unknown-linux-gnu --all-features
         env:
           BYOND_BIN: /home/runner/BYOND/byond/bin
+
       - name: Build (release) (default features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: build
           args: --target i686-unknown-linux-gnu --release
+
       - uses: actions/upload-artifact@v1
         with:
           name: rust_g

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a"
 dependencies = [
  "bitflags",
 ]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Bjorn Neergaard, /tg/station contributors
+Copyright (c) 2022 Bjorn Neergaard, rust-g contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 rust-g (pronounced rusty-g) is a library which offloads certain expensive or
 difficult tasks from BYOND.
 
-This library is currently used in the [tgstation] codebase, and is required for
+This library is currently used in the [/tg/station] codebase, and is required for
 it to run. A pre-compiled DLL version can be found in the repo root, but you
 can build your own from this repo at your preference. Builds can also be found
 on the [releases page].
@@ -178,7 +178,7 @@ open("rust_g", O_RDONLY|O_NONBLOCK|O_LARGEFILE|O_DIRECTORY|O_CLOEXEC) = -1 ENOTD
 If you're still having problems, ask in the [Coderbus Discord]'s
 `#tooling-questions` channel.
 
-You can also try [tgstation]'s IRC, `#coderbus` on Rizon, but it is usually
+You can also try [/tg/station]'s IRC, `#coderbus` on Rizon, but it is usually
 quiet.
 
 [/tg/station]: https://github.com/tgstation/tgstation

--- a/README.md
+++ b/README.md
@@ -178,9 +178,6 @@ open("rust_g", O_RDONLY|O_NONBLOCK|O_LARGEFILE|O_DIRECTORY|O_CLOEXEC) = -1 ENOTD
 If you're still having problems, ask in the [Coderbus Discord]'s
 `#tooling-questions` channel.
 
-You can also try [/tg/station]'s IRC, `#coderbus` on Rizon, but it is usually
-quiet.
-
 [/tg/station]: https://github.com/tgstation/tgstation
 [Rust]: https://rust-lang.org
 [Cargo]: https://doc.rust-lang.org/cargo/


### PR DESCRIPTION
rust-g compile time without caching: 11m20s linux, 13m41s windows
with cache: 4m8s linux, 4m34s windows