### PR TITLE
Pallette Encoding Image Fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rust-g"
 edition = "2021"
 version = "1.0.0"
-authors = ["Bjorn Neergaard <bjorn@neersighted.com>, Tad Hardesty <tad@platymuus.com>, rust-g maintainer team"]
+authors = ["Bjorn Neergaard <bjorn@neersighted.com>", "Tad Hardesty <tad@platymuus.com>", "rust-g maintainer team"]
 repository = "https://github.com/tgstation/rust-g"
 license = "MIT"
 description = "Offloaded task library for the /tg/ Space Station 13 codebase"


### PR DESCRIPTION
Should copy palette information over for the metadata stripping operation now so the encoding doesn't fail. 

<details>
<summary>Rant</summary>
Annoyingly, the `png` changelog didn't hint at this palette issue - though I'm not entirely sure how it was getting the info before. Nor do I think it's the difference between `png::Info` vs `png::OutputInfo`. Probably some internal mechanism for checking it got changed and our produced images had no palette information before.
</details>

Also threw in a zTxt copy mechanism if at some point we want it, because we now have access to that information there and it's possible in the new library version.

Fixes issue brought up in: https://github.com/tgstation/tgstation/pull/68690