### PR TITLE
Fix clippy errors in hash.rs

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -24,7 +24,7 @@ byond_fn!(fn hash_file(algorithm, string) {
 byond_fn!(fn generate_totp(hex_seed) {
     match totp_generate(hex_seed, 0, None) {
         Ok(value) => Some(value),
-        Err(error) => return Some(format!("ERROR: {:?}", error))
+        Err(error) => Some(format!("ERROR: {:?}", error))
     }
 });
 
@@ -35,7 +35,7 @@ byond_fn!(fn generate_totp_tolerance(hex_seed, tolerance) {
     };
     match totp_generate_tolerance(hex_seed, tolerance_value, None) {
         Ok(value) => Some(value),
-        Err(error) => return Some(format!("ERROR: {:?}", error))
+        Err(error) => Some(format!("ERROR: {:?}", error))
     }
 });
 


### PR DESCRIPTION
Unneeded returns removed, it was freaking out clippy

![image](https://user-images.githubusercontent.com/25491240/185804354-9f553d87-a29c-4233-b2e0-dac494a5e60f.png)
