### PR TITLE
Change unix timestamp to return a string

### DIFF
--- a/dmsrc/time.dm
+++ b/dmsrc/time.dm
@@ -2,5 +2,6 @@
 #define rustg_time_milliseconds(id) text2num(RUSTG_CALL(RUST_G, "time_milliseconds")(id))
 #define rustg_time_reset(id) RUSTG_CALL(RUST_G, "time_reset")(id)
 
+/// Returns the timestamp as a string
 /proc/rustg_unix_timestamp()
-	return text2num(RUSTG_CALL(RUST_G, "unix_timestamp")())
+	return RUSTG_CALL(RUST_G, "unix_timestamp")()


### PR DESCRIPTION
Byond rounds the Unix timestamp to the nearest minute because of how shit a language it is.