### PR TITLE
Replace flume with crossbeam in HTTP

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,13 +20,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Clippy (all features)
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: stable
-          command: clippy
-          args: --target i686-pc-windows-msvc --all-features --locked -- -D warnings
-
       - name: Rustfmt
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
  "cfg-if",
  "crossbeam-channel",
@@ -1858,6 +1858,7 @@ dependencies = [
  "base64",
  "chrono",
  "const-random",
+ "crossbeam",
  "dashmap",
  "dbpnoise",
  "flume",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ debug = true
 
 [dependencies]
 thiserror = "1.0"
+crossbeam = { version = "0.8.2", optional = true }
 flume = { version = "0.10", optional = true }
 chrono = { version = "0.4", optional = true }
 base64 = { version = "0.13", optional = true }
@@ -34,7 +35,9 @@ hex = { version = "0.4", optional = true }
 percent-encoding = { version = "2.1", optional = true }
 url-dep = { version = "2.1", package = "url", optional = true }
 png = { version = "0.17", optional = true }
-image = { version = "0.24", optional = true, default-features = false, features = ["png"] }
+image = { version = "0.24", optional = true, default-features = false, features = [
+    "png",
+] }
 git2 = { version = "0.14", optional = true, default-features = false }
 noise = { version = "0.8", optional = true }
 redis = { version = "0.21", optional = true }
@@ -107,7 +110,7 @@ unzip = ["zip", "jobs"]
 worleynoise = ["rand", "rayon"]
 
 # internal feature-like things
-jobs = ["flume"]
+jobs = ["crossbeam"]
 
 [dev-dependencies]
 regex = "1"


### PR DESCRIPTION
We're getting a really weird panic in this area of the code and it seems to be a result of flume unwinding.

This is a shot in the dark experiment to see if using the much more popular and battle-tested crossbeam will resolve this issue. Long term we need to agree on what panic hooks should do (exit DD? try to handle when an error is expected (like HTTP)? just return *something* and let DM code fail silently?) and get them in. If this PR actually should be merged because flume is erroneous, then we need to remove it completely in redis as well, so this is a draft.