### PR TITLE
New FFI Macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -149,6 +149,25 @@ name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
+name = "byond_fn"
+version = "0.4.0"
+dependencies = [
+ "byond_fn_impl",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "byond_fn_impl"
+version = "0.4.0"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
 
 [[package]]
 name = "bytemuck"
@@ -460,7 +479,7 @@ checksum = "532b4c15dccee12c7044f1fcad956e98410860b22231e44a3b827464797ca7bf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -590,7 +609,7 @@ checksum = "3dbc4f084ec5a3f031d24ccedeb87ab2c3189a2f33b8d070889073837d5ea09e"
 dependencies = [
  "frunk_proc_macro_helpers",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -602,7 +621,7 @@ dependencies = [
  "frunk_core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -626,7 +645,7 @@ dependencies = [
  "frunk_proc_macro_helpers",
  "proc-macro-hack",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -921,7 +940,7 @@ dependencies = [
  "autocfg",
  "derive_utils",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1444,7 +1463,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1555,7 +1574,7 @@ checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1595,6 +1614,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.98",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,18 +1645,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -1856,6 +1899,7 @@ version = "1.2.0"
 dependencies = [
  "aho-corasick",
  "base64",
+ "byond_fn",
  "chrono",
  "const-random",
  "dashmap",
@@ -2005,7 +2049,7 @@ checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -2159,6 +2203,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,7 +2250,7 @@ checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -2458,7 +2513,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -2492,7 +2547,7 @@ checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ debug = true
 
 [dependencies]
 thiserror = "1.0"
+byond_fn = "0.5"
 flume = { version = "0.10", optional = true }
 chrono = { version = "0.4", optional = true }
 base64 = { version = "0.13", optional = true }

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,16 +1,16 @@
+use byond_fn::byond_fn;
 use serde_json::Value;
 use std::cmp;
 
 const VALID_JSON_MAX_RECURSION_DEPTH: usize = 8;
 
-byond_fn!(fn json_is_valid(text) {
-    let value = match serde_json::from_str::<Value>(text) {
-        Ok(value) => value,
-        Err(_) => return Some("false".to_owned())
-    };
-
-    Some(get_recursion_level(&value).is_ok().to_string())
-});
+#[byond_fn]
+fn json_is_valid(text: &str) -> bool {
+    match serde_json::from_str::<Value>(text) {
+        Ok(value) => get_recursion_level(&value).is_ok(),
+        Err(_) => false,
+    }
+}
 
 /// Gets the recursion level of the given value
 /// If it is above VALID_JSON_MAX_RECURSION_DEPTH, returns Err(())

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,49 +1,47 @@
+use std::time::{Duration, SystemTime, SystemTimeError};
 use std::{
     cell::RefCell,
     collections::hash_map::{Entry, HashMap},
     time::Instant,
 };
 
+use byond_fn::byond_fn;
+
 thread_local!( static INSTANTS: RefCell<HashMap<String, Instant>> = RefCell::new(HashMap::new()) );
 
-byond_fn!(fn time_microseconds(instant_id) {
+fn time(instant_id: String) -> Duration {
     INSTANTS.with(|instants| {
         let mut map = instants.borrow_mut();
         let instant = match map.entry(instant_id.into()) {
             Entry::Occupied(elem) => elem.into_mut(),
             Entry::Vacant(elem) => elem.insert(Instant::now()),
         };
-        Some(instant.elapsed().as_micros().to_string())
+        instant.elapsed()
     })
-});
+}
 
-byond_fn!(fn time_milliseconds(instant_id) {
-    INSTANTS.with(|instants| {
-        let mut map = instants.borrow_mut();
-        let instant = match map.entry(instant_id.into()) {
-            Entry::Occupied(elem) => elem.into_mut(),
-            Entry::Vacant(elem) => elem.insert(Instant::now()),
-        };
-        Some(instant.elapsed().as_millis().to_string())
-    })
-});
+#[byond_fn]
+fn time_microseconds(instant_id: String) -> String {
+    time(instant_id).as_micros().to_string()
+}
 
-byond_fn!(fn time_reset(instant_id) {
+#[byond_fn]
+fn time_milliseconds(instant_id: String) -> String {
+    time(instant_id).as_millis().to_string()
+}
+
+#[byond_fn]
+fn time_reset(instant_id: String) {
     INSTANTS.with(|instants| {
         let mut map = instants.borrow_mut();
         map.insert(instant_id.into(), Instant::now());
-        Some("")
     })
-});
+}
 
-byond_fn!(
-    fn unix_timestamp() {
-        Some(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs_f64()
-                .to_string(),
-        )
-    }
-);
+#[byond_fn]
+fn unix_timestamp() -> Result<String, SystemTimeError> {
+    SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|x| x.as_secs_f64())
+        .map(|x| x.to_string())
+}

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,25 +1,24 @@
 use crate::error::Result;
+use byond_fn::byond_fn;
 use std::borrow::Cow;
 use url_dep::form_urlencoded::byte_serialize;
-
-byond_fn!(fn url_encode(data) {
-    Some(encode(data))
-});
 
 byond_fn!(fn url_decode(data) {
     decode(data).ok()
 });
 
-fn encode(string: &str) -> String {
+#[byond_fn]
+fn url_encode(string: &str) -> String {
     byte_serialize(string.as_bytes()).collect()
 }
 
-fn decode(string: &str) -> Result<String> {
+#[byond_fn]
+fn url_decode(string: &str) -> String {
     let replaced = replace_plus(string.as_bytes());
     // into_owned() is not strictly necessary here, but saves some refactoring work.
-    Ok(percent_encoding::percent_decode(&replaced)
+    percent_encoding::percent_decode(&replaced)
         .decode_utf8_lossy()
-        .into_owned())
+        .into_owned()
 }
 
 // From `url` crate.


### PR DESCRIPTION
Brand new ludicrously overengineered macro for automagically™ interoping with byond smoothly and cleanly.

## Here's what you can do with the new macro
All of these are callable directly from byond.
### Write bare functions without being wrapped in a macro
```rust
#[byond_fn]
pub fn example_byond_fn() {
    let x = "yeah, we can bind vars";
    println!("{x}");
}
```
### Have string arguments and return strings
```rust
#[byond_fn]
pub fn concat(first: &str, second: &str) -> String {
    format!("{first}{second")
}
```
### Have arbitrary args that can be parsed from strings and return arbitrary types that can be converted to strings
```rust
#[byond_fn]
pub fn add(arg1: u8, arg2: u8) -> u8 {
    arg1 + arg2
}
```
### Have some arguments be optional and not required to be passed
```rust
#[byond_fn]
pub fn example_optional_params(arg1: u8, arg2: Option<u8>) -> u8 {
    arg1 + arg2.unwrap_or(0)
}
```

### Gracefully handle errors
```rust
#[byond_fn]
pub fn do_something_falliable(dunno: &str) -> Result<String, WhateverError> {
    let cool = probably_something_cool(dunno)?;
    let oh_no = actually_it_was_lame(cool)?;
    Ok(oh_no)
}
```

### Automagic JSON Transport
```rust
pub fn fungle_the_goobler(goobler: Json<Goobler>) -> Json<Fungled> {
    let fungled = goobler.into_inner().fungle();
    Json(fungled)
}
```


New macro lives here (at the moment): https://github.com/actioninja/byond_fn

Docs here: https://docs.rs/byond_fn/0.5.1/byond_fn/

## How the hell does this work?

In a very overcomplicated way

The tl;dr is it uses a trait to parse arguments from strings, and a separate trait to serialize back to string. There's blanket impls over Option and Result as well for optional args and error handling respectively.

This will be better documented later, read the code, the docs, etc

## Error handling

This is very much in flux right now. Especially considering that the best way to handle this may change when FFI V2 becomes available. How it currently works can be found in the docs (though these docs may not be accurate atm): https://docs.rs/byond_fn/0.5.1/byond_fn/str_ffi/index.html#errors

## Goals

I never really was super happy with the existing macro. Since it puts the function body inside a macro call, you lose a lot of IDE niceness since inside macros could be anything. On top of that, it always was kind of weird to me that each function was expected to just do the boilerplate of parsing each string argument manually when this is going to be the same in the overwhelming amount of usecases.

The unclear and not well documented nature of the previous macro resulted in a lot of cargo cult as well. Lots of functions that return results despite having no fallibility.

Someone mentioned in coderbus a while ago that it would be nice if the actual FFI junk could be pulled out of rust-g so it could be reused elsewhere more easily. Since proc macros require their own crate anyways, this makes a good opportunity to do so.

## `byond_fn` todo

- [ ] Finalize the argument structure and how FFI types should be specified
- [ ] Finalize the error handling structure
- [ ] Implement some way of automatically generating the byond-side call signature (companion crate for usage in build.rs?)
- [ ] Fully cover all pub api with documentation
- [ ] Write some basic unit tests
- [ ] Implement the new byond FFI interface

# Things that should happen before this is merged

- [ ] finalize `byond_fn` structure and output and hit 1.0 (above todo list should be finished)
- [ ] convert all existing functions in rust-g to use the new macro
- [ ] bring `byond_fn` under the tgstation org and give more accounts crates.io publish perms
- [ ] run a built binary using the new macro in prod for a while to check against regressions