### PR TITLE
Some pedantic and nursery clippy lints

### DIFF
--- a/src/cellularnoise.rs
+++ b/src/cellularnoise.rs
@@ -71,10 +71,10 @@ fn noise_gen(
     });
 
     //then we cut it
-    let map = (1..width + 1)
+    let map = (1..=width)
         .into_par_iter()
         .map(|x| {
-            (1..height + 1)
+            (1..=height)
                 .map(|y| filled_vec[x][y])
                 .collect::<Vec<bool>>()
         })

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -27,7 +27,7 @@ byond_fn!(fn dmi_resize_png(path, width, height, resizetype) {
 
 fn strip_metadata(path: &str) -> Result<()> {
     let (reader, frame_info, image) = read_png(path)?;
-    write_png(path, reader, frame_info, image, true)
+    write_png(path, &reader, &frame_info, &image, true)
 }
 
 fn read_png(path: &str) -> Result<(Reader<File>, OutputInfo, Vec<u8>)> {
@@ -40,9 +40,9 @@ fn read_png(path: &str) -> Result<(Reader<File>, OutputInfo, Vec<u8>)> {
 
 fn write_png(
     path: &str,
-    reader: Reader<File>,
-    info: OutputInfo,
-    image: Vec<u8>,
+    reader: &Reader<File>,
+    info: &OutputInfo,
+    image: &[u8],
     strip: bool,
 ) -> Result<()> {
     let mut encoder = Encoder::new(File::create(path)?, info.width, info.height);
@@ -50,11 +50,11 @@ fn write_png(
     encoder.set_depth(info.bit_depth);
 
     let reader_info = reader.info();
-    if let Some(palette) = reader_info.palette.to_owned() {
+    if let Some(palette) = reader_info.palette.clone() {
         encoder.set_palette(palette);
     }
 
-    if let Some(trns_chunk) = reader_info.trns.to_owned() {
+    if let Some(trns_chunk) = reader_info.trns.clone() {
         encoder.set_trns(trns_chunk);
     }
 
@@ -65,7 +65,7 @@ fn write_png(
             writer.write_text_chunk(chunk)?;
         }
     }
-    Ok(writer.write_image_data(&image)?)
+    Ok(writer.write_image_data(image)?)
 }
 
 fn create_png(path: &str, width: &str, height: &str, data: &str) -> Result<()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,8 +64,8 @@ pub enum Error {
 }
 
 impl From<Utf8Error> for Error {
-    fn from(source: Utf8Error) -> Error {
-        Error::Utf8 {
+    fn from(source: Utf8Error) -> Self {
+        Self::Utf8 {
             source,
             position: source.valid_up_to(),
         }
@@ -73,13 +73,13 @@ impl From<Utf8Error> for Error {
 }
 
 impl From<Error> for String {
-    fn from(error: Error) -> String {
+    fn from(error: Error) -> Self {
         error.to_string()
     }
 }
 
 impl From<Error> for Vec<u8> {
-    fn from(error: Error) -> Vec<u8> {
+    fn from(error: Error) -> Self {
         error.to_string().into_bytes()
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -89,5 +89,5 @@ fn get_line_count(path: &str) -> Result<u32> {
 
 fn seek_line(path: &str, line: usize) -> Option<String> {
     let file = BufReader::new(File::open(path).ok()?);
-    file.lines().nth(line).and_then(|line| line.ok())
+    file.lines().nth(line).and_then(std::result::Result::ok)
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -70,10 +70,7 @@ fn setup_http_client() -> reqwest::blocking::Client {
     };
 
     let mut headers = HeaderMap::new();
-    headers.insert(
-        USER_AGENT,
-        format!("{}/{}", PKG_NAME, VERSION).parse().unwrap(),
-    );
+    headers.insert(USER_AGENT, format!("{PKG_NAME}/{VERSION}").parse().unwrap());
 
     Client::builder().default_headers(headers).build().unwrap()
 }

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -52,7 +52,7 @@ impl Jobs {
 }
 
 thread_local! {
-    static JOBS: RefCell<Jobs> = Default::default();
+    static JOBS: RefCell<Jobs> = RefCell::default();
 }
 
 pub fn start<F: FnOnce() -> Output + Send + 'static>(f: F) -> JobId {

--- a/src/json.rs
+++ b/src/json.rs
@@ -13,7 +13,7 @@ byond_fn!(fn json_is_valid(text) {
 });
 
 /// Gets the recursion level of the given value
-/// If it is above VALID_JSON_MAX_RECURSION_DEPTH, returns Err(())
+/// If it is above `VALID_JSON_MAX_RECURSION_DEPTH`, returns Err(())
 fn get_recursion_level(value: &Value) -> Result<usize, ()> {
     let values: Vec<&Value> = match value {
         Value::Array(array) => array.iter().collect(),

--- a/src/log.rs
+++ b/src/log.rs
@@ -26,7 +26,7 @@ byond_fn!(fn log_write(path, data, ...rest) {
 
         if rest.first().map(|x| &**x) == Some("false") {
             // Write the data to the file with no accoutrements.
-            write!(file, "{}", data)?;
+            write!(file, "{data}")?;
         } else {
             // write first line, timestamped
             let mut iter = data.split('\n');
@@ -36,7 +36,7 @@ byond_fn!(fn log_write(path, data, ...rest) {
 
             // write remaining lines
             for line in iter {
-                writeln!(file, " - {}", line)?;
+                writeln!(file, " - {line}")?;
             }
         }
 
@@ -56,7 +56,7 @@ byond_fn!(
 
 fn open(path: &Path) -> Result<File> {
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?
+        fs::create_dir_all(parent)?;
     }
 
     Ok(OpenOptions::new().append(true).create(true).open(path)?)

--- a/src/noise_gen.rs
+++ b/src/noise_gen.rs
@@ -32,7 +32,7 @@ fn get_at_coordinates(seed_as_str: &str, x_as_str: &str, y_as_str: &str) -> Resu
         //perlin noise produces a result in [-sqrt(0.5), sqrt(0.5)] which we scale to [0, 1] for simplicity
         let unscaled = generator.get([x, y]);
         let scaled = (unscaled * 2.0_f64.sqrt() + 1.0) / 2.0;
-        let clamped = scaled.min(1.0).max(0.0);
+        let clamped = scaled.clamp(0.0, 1.0);
         Ok(clamped.to_string())
     })
 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -204,13 +204,12 @@ fn do_query(handle: &str, query: &str, params: &str) -> Result<serde_json::Value
                 mysql::Value::UInt(u) => serde_json::Value::Number(Number::from(*u)),
                 mysql::Value::Date(year, month, day, hour, minute, second, _ms) => {
                     serde_json::Value::String(format!(
-                        "{}-{:02}-{:02} {:02}:{:02}:{:02}",
-                        year, month, day, hour, minute, second
+                        "{year}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}"
                     ))
                 }
                 _ => serde_json::Value::Null,
             };
-            json_row.push(converted)
+            json_row.push(converted);
         }
         rows.push(serde_json::Value::Array(json_row));
     }


### PR DESCRIPTION
Does a bunch of clippy pedantic and nursery lints, mostly just cleanliness/idiomatic stuff. No functionality changes (other than things like ""performance"" due to using borrowed instead of copied values).

Should this be merged?
![image](https://github.com/tgstation/rust-g/assets/4741640/9910496d-fa6c-4175-a744-ceba653bdfcf)
