### PR TITLE
add uniform precision to rust-g timestamp

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -38,13 +38,12 @@ byond_fn!(fn time_reset(instant_id) {
 
 byond_fn!(
     fn unix_timestamp() {
-        Some(
-            format!(
-                "{:.6}",
-                std::time::SystemTime::now()
+        Some(format!(
+            "{:.6}",
+            std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
-                .as_secs_f64()),
-        )
+                .as_secs_f64()
+        ))
     }
 );

--- a/src/time.rs
+++ b/src/time.rs
@@ -39,11 +39,12 @@ byond_fn!(fn time_reset(instant_id) {
 byond_fn!(
     fn unix_timestamp() {
         Some(
-            std::time::SystemTime::now()
+            format!(
+                "{:.6}",
+                std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
-                .as_secs_f64()
-                .to_string(),
+                .as_secs_f64()),
         )
     }
 );


### PR DESCRIPTION
I forgot to do this apparentally

Fixes #142 