### PR TITLE
Make mysql use the native rust tls stack by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           toolchain: stable
           command: build
-          args: --target i686-pc-windows-msvc --release
+          args: --target i686-pc-windows-msvc --locked --release
 
       - uses: actions/upload-artifact@v3
         with:
@@ -78,21 +78,21 @@ jobs:
         with:
           toolchain: stable
           command: check
-          args: --target i686-unknown-linux-gnu --features all
+          args: --target i686-unknown-linux-gnu --locked --features all
 
       - name: Build (Debug) (all features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: build
-          args: --target i686-unknown-linux-gnu --features all
+          args: --target i686-unknown-linux-gnu --locked --features all
 
       - name: Run tests (all features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: test
-          args: --target i686-unknown-linux-gnu --features all
+          args: --target i686-unknown-linux-gnu --locked --features all
         env:
           BYOND_BIN: /home/runner/BYOND/byond/bin
 
@@ -101,7 +101,7 @@ jobs:
         with:
           toolchain: stable
           command: build
-          args: --target i686-unknown-linux-gnu --release
+          args: --target i686-unknown-linux-gnu --locked --release
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           toolchain: stable
           command: clippy
-          args: --target i686-pc-windows-msvc --all-features --locked -- -D warnings
+          args: --target i686-pc-windows-msvc --features all --locked -- -D warnings
 
       - name: Rustfmt
         uses: actions-rs/cargo@v1
@@ -78,21 +78,21 @@ jobs:
         with:
           toolchain: stable
           command: check
-          args: --target i686-unknown-linux-gnu --all-features
+          args: --target i686-unknown-linux-gnu --features all
 
       - name: Build (Debug) (all features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: build
-          args: --target i686-unknown-linux-gnu --all-features
+          args: --target i686-unknown-linux-gnu --features all
 
       - name: Run tests (all features)
         uses: actions-rs/cargo@v1
         with:
           toolchain: stable
           command: test
-          args: --target i686-unknown-linux-gnu --all-features
+          args: --target i686-unknown-linux-gnu --features all
         env:
           BYOND_BIN: /home/runner/BYOND/byond/bin
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "rust-g"
-version = "3.0.0"
+version = "2.1.0"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "rust-g"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,11 +1431,15 @@ dependencies = [
  "once_cell",
  "pem",
  "percent-encoding",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "socket2 0.5.3",
  "twox-hash",
  "url",
+ "webpki",
+ "webpki-roots 0.23.1",
 ]
 
 [[package]]
@@ -2113,7 +2117,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -2962,6 +2966,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-g"
 edition = "2021"
-version = "3.0.0"
+version = "2.1.0"
 authors = [
     "Bjorn Neergaard <bjorn@neersighted.com>",
     "Tad Hardesty <tad@platymuus.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-g"
 edition = "2021"
-version = "2.1.0"
+version = "3.0.0"
 authors = [
     "Bjorn Neergaard <bjorn@neersighted.com>",
     "Tad Hardesty <tad@platymuus.com>",
@@ -46,7 +46,7 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 lazy_static = { version = "1.4", optional = true }
 once_cell = { version = "1.17", optional = true }
-mysql = { version = "24.0", optional = true }
+mysql = { version = "24.0", default_features = false, optional = true}
 dashmap = { version = "5.4", optional = true }
 zip = { version = "0.6", optional = true }
 rand = { version = "0.8", optional = true }
@@ -69,6 +69,7 @@ default = [
     "json",
     "log",
     "noise",
+    "rustls_tls",
     "sql",
     "time",
     "toml",
@@ -107,6 +108,10 @@ redis_pubsub = ["flume", "redis", "serde", "serde_json"]
 redis_reliablequeue = ["flume", "redis", "serde", "serde_json"]
 unzip = ["zip", "jobs"]
 worleynoise = ["rand", "rayon"]
+
+# Use the native tls stack for the mysql db
+native_tls = ["mysql/default"]
+rustls_tls = ["mysql/default-rustls"]
 
 # internal feature-like things
 jobs = ["flume"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,30 @@ default = [
     "url",
 ]
 
+all = [
+    "acreplace",
+    "cellularnoise",
+    "dmi",
+    "file",
+    "git",
+    "http",
+    "json",
+    "log",
+    "noise",
+    "rustls_tls",
+    "sql",
+    "time",
+    "toml",
+    "url",
+    "batchnoise",
+    "hash",
+    "pathfinder",
+    "redis_pubsub",
+    "redis_reliablequeue",
+    "unzip",
+    "worleynoise"
+]
+
 # default features
 acreplace = ["aho-corasick"]
 cellularnoise = ["rand", "rayon"]


### PR DESCRIPTION
This removes the dependency on libssl, which is one of the few remaining dependencies that it has beyond libc

This is a major version bump because there may be some inconsistencies with the tls certs suported by rustls

https://docs.rs/mysql/latest/mysql/#ssl-support

You can opt back into the native stack if you so choose