### PR TITLE
Revert "3.0.0"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
       - run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install libgcc-s1:i386 g++-multilib zlib1g-dev:i386
+          sudo apt-get install libgcc-s1:i386 g++-multilib zlib1g-dev:i386 libssl-dev:i386
           ./scripts/install_byond.sh
 
       - uses: actions-rs/toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "rust-g"
-version = "3.0.0"
+version = "2.1.0"
 dependencies = [
  "aho-corasick",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-g"
 edition = "2021"
-version = "3.0.0"
+version = "2.1.0"
 authors = [
     "Bjorn Neergaard <bjorn@neersighted.com>",
     "Tad Hardesty <tad@platymuus.com>",

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ System libraries:
     ```sh
     sudo dpkg --add-architecture i386
     sudo apt-get update
-    sudo apt-get install zlib1g-dev:i386
+    sudo apt-get install zlib1g-dev:i386 libssl-dev:i386
     ```
 
 * Other Linux distributions install the appropriate **32-bit development** and **32-bit runtime** packages.
@@ -84,8 +84,7 @@ cargo build --release --target i686-pc-windows-msvc
 
 If you aren't sharing the binary with other people, consider compiling [targeting your native cpu](https://rust-lang.github.io/packed_simd/perf-guide/target-feature/rustflags.html#target-cpu) for potential performance improvements. You can do this by setting the `RUSTFLAGS` environment variable to `-C target-cpu=native`. For example, in Powershell you would use `$Env:RUSTFLAGS="-C target-cpu=native"`.
 
-To get additional features, pass a list to `--features`, for example `--features hash,url`. To get all features, pass `--features all`. To disable the default features, pass `--no-default-features`.
-You can't use `--all-features` because of conflicting `native_tls` and `rustls_tls` features to select the mysql backend.
+To get additional features, pass a list to `--features`, for example `--features hash,url`. To get all features, pass `--all-features`. To disable the default features, pass `--no-default-features`.
 
 The default features are:
 * acreplace: Aho-Corasick string matching and replacement.
@@ -140,13 +139,16 @@ sample output, but the most important thing is that nothing is listed as
 
 ```sh
 $ ldd librust_g.so  # Linux
-    linux-gate.so.1 (0xf7f8b000)
-    libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf7957000)
-    libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf7935000)
-    libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf7831000)
-    libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf782b000)
-    libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7643000)
-    /lib/ld-linux.so.2 (0xf7f8d000)
+    linux-gate.so.1 (0xf7f45000)
+    libssl.so.1.1 => /usr/lib/i386-linux-gnu/libssl.so.1.1 (0xf6c79000)
+    libcrypto.so.1.1 => /usr/lib/i386-linux-gnu/libcrypto.so.1.1 (0xf69cd000)
+    libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf69c8000)
+    librt.so.1 => /lib/i386-linux-gnu/librt.so.1 (0xf69be000)
+    libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf699f000)
+    libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf6981000)
+    libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf67a5000)
+    /lib/ld-linux.so.2 (0xf7f47000)
+    libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf66a3000)
 ```
 
 If BYOND cannot find the shared library, ensure that the directory containing

--- a/docker/Dockerfile.i686-unknown-linux-gnu
+++ b/docker/Dockerfile.i686-unknown-linux-gnu
@@ -2,4 +2,4 @@ FROM rustembedded/cross:i686-unknown-linux-gnu
 
 RUN dpkg --add-architecture i386 && \
 	apt-get update && \
-	apt-get install --assume-yes zlib1g-dev:i386 pkg-config:i386
+	apt-get install --assume-yes zlib1g-dev:i386 libssl-dev:i386 pkg-config:i386


### PR DESCRIPTION
Reverts tgstation/rust-g#147

Makes the server crash on round restart on windows.

This kills pop counts because people don't always reconnect and its common for players to decide to end a play session if they meet the slightest resistance.