### PR TITLE
Updates `rustg_file_exists()` macro to remove user error

### DIFF
--- a/dmsrc/file.dm
+++ b/dmsrc/file.dm
@@ -1,5 +1,5 @@
 #define rustg_file_read(fname) RUSTG_CALL(RUST_G, "file_read")(fname)
-#define rustg_file_exists(fname) RUSTG_CALL(RUST_G, "file_exists")(fname)
+#define rustg_file_exists(fname) (RUSTG_CALL(RUST_G, "file_exists")(fname) == "true")
 #define rustg_file_write(text, fname) RUSTG_CALL(RUST_G, "file_write")(text, fname)
 #define rustg_file_append(text, fname) RUSTG_CALL(RUST_G, "file_append")(text, fname)
 #define rustg_file_get_line_count(fname) text2num(RUSTG_CALL(RUST_G, "file_get_line_count")(fname))


### PR DESCRIPTION
Closes #153 

Creates truthy-ness parity with byond's fexists() function.

