### PR TITLE
IconForge - Building spritesheets at the speed of light

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,8 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+ "rayon",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "dmi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754c4784da61ad948b8bc868b3f639b102f798567576044fe67f5b7c70044c8f"
+checksum = "a99b0d2dae3ac6a37fe16dae423852e78b4d3279f86fe0958bd0549540952ffc"
 dependencies = [
  "bitflags 2.4.1",
  "deflate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,13 +686,8 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "dunce"
 version = "1.0.4"
-=======
-name = "dtoa"
-version = "0.4.8"
->>>>>>> 47bfb12 (iconforge beta)
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
@@ -764,15 +759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fdeflate"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d6dafc854908ff5da46ff3f8f473c6984119a2876a383a860246dd7841a868"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,7 +772,7 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide 0.5.3",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1710,22 +1696,8 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "indexmap"
 version = "2.1.0"
-=======
-name = "inflate"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
-dependencies = [
- "adler32",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
->>>>>>> 47bfb12 (iconforge beta)
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
@@ -2007,16 +1979,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
-dependencies = [
- "adler",
- "simd-adler32",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2412,11 +2374,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
-<<<<<<< HEAD
  "miniz_oxide",
-=======
- "miniz_oxide 0.7.1",
->>>>>>> 47bfb12 (iconforge beta)
 ]
 
 [[package]]
@@ -2809,6 +2767,7 @@ dependencies = [
  "gix",
  "hex",
  "image",
+ "lazy_static",
  "md-5",
  "mysql",
  "noise",
@@ -2827,12 +2786,8 @@ dependencies = [
  "sha-1",
  "sha2",
  "thiserror",
-<<<<<<< HEAD
  "toml 0.8.8",
-=======
- "toml",
  "tracy_full",
->>>>>>> 47bfb12 (iconforge beta)
  "twox-hash",
  "url",
  "zip",
@@ -2867,7 +2822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-<<<<<<< HEAD
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,14 +2841,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
-=======
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
->>>>>>> 47bfb12 (iconforge beta)
 ]
 
 [[package]]
@@ -3118,12 +3073,6 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,13 +47,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -138,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.68.1"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+checksum = "9ffcebc3849946a7170a05992aac39da343a90676ab392c51a4280981d6379c2"
 dependencies = [
  "bitflags 2.4.1",
  "cexpr",
@@ -191,47 +192,26 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.10.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
+checksum = "26d4d6dafc1a3bb54687538972158f07b2c948bc57d5890df22c0739098b3028"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.13.2",
+ "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.10.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
+checksum = "bf4918709cc4dd777ad2b6303ed03cb37f3ca0ccede8c1b0d28ac6db8f4710e0"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
+ "once_cell",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.42",
+ "syn_derive",
 ]
 
 [[package]]
@@ -241,7 +221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata",
  "serde",
 ]
 
@@ -353,6 +333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,9 +432,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -675,10 +661,11 @@ dependencies = [
 
 [[package]]
 name = "dmi"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c191706391473812b2c9f11befada49b65e094a19d3d422985f0d1e2daf900"
+checksum = "754c4784da61ad948b8bc868b3f639b102f798567576044fe67f5b7c70044c8f"
 dependencies = [
+ "bitflags 2.4.1",
  "deflate",
  "image",
  "inflate",
@@ -877,9 +864,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
 ]
@@ -892,20 +879,9 @@ checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.42",
-]
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-sink"
@@ -915,19 +891,18 @@ checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -971,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "gix"
@@ -1483,9 +1458,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
 dependencies = [
  "bytes",
  "fnv",
@@ -1493,7 +1468,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1515,7 +1490,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
 ]
 
 [[package]]
@@ -1562,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",
@@ -1573,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
@@ -1596,9 +1571,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1611,7 +1586,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1620,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http",
@@ -1687,16 +1662,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
@@ -1744,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itoa"
@@ -1992,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -2024,7 +1989,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "twox-hash",
  "url",
  "webpki",
@@ -2221,9 +2186,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2253,9 +2218,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
 dependencies = [
  "cc",
  "libc",
@@ -2305,7 +2270,7 @@ checksum = "f6f4a3f5089b981000cb50ec24320faf7a19649a45e8730e4adf49f78f066528"
 dependencies = [
  "deprecate-until",
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap",
  "integer-sqrt",
  "num-traits",
  "rustc-hash",
@@ -2391,21 +2356,21 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml 0.5.11",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -2626,24 +2591,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
-dependencies = [
- "aho-corasick",
- "memchr",
+ "regex-automata",
  "regex-syntax",
 ]
 
@@ -2652,12 +2606,17 @@ name = "regex-automata"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rend"
@@ -2704,7 +2663,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.2",
+ "webpki-roots 0.25.3",
  "winreg",
 ]
 
@@ -2718,9 +2677,23 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+dependencies = [
+ "cc",
+ "getrandom 0.2.11",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2786,7 +2759,7 @@ dependencies = [
  "sha-1",
  "sha2",
  "thiserror",
- "toml 0.8.8",
+ "toml",
  "tracy_full",
  "twox-hash",
  "url",
@@ -2795,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.32.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c4216490d5a413bc6d10fa4742bd7d4955941d062c0ef873141d6b0e7b30fd"
+checksum = "06676aec5ccb8fc1da723cc8c0f9a46549f21ebb8753d3915c6c41db1e7f1dc4"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2845,21 +2818,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki 0.101.6",
+ "ring 0.17.7",
+ "rustls-webpki 0.101.7",
  "sct",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
 ]
@@ -2870,18 +2843,18 @@ version = "0.100.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.6"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2922,12 +2895,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3101,9 +3074,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -3175,6 +3148,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3216,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
@@ -3300,9 +3285,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3310,7 +3295,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "windows-sys 0.48.0",
 ]
 
@@ -3326,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3336,15 +3321,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3374,7 +3350,18 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -3385,7 +3372,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3400,20 +3387,19 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
@@ -3440,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
@@ -3451,7 +3437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -3502,6 +3488,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3590,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3631,9 +3623,9 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3641,12 +3633,12 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3660,9 +3652,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "winapi"
@@ -3871,6 +3863,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,8 +686,13 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "dunce"
 version = "1.0.4"
+=======
+name = "dtoa"
+version = "0.4.8"
+>>>>>>> 47bfb12 (iconforge beta)
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
@@ -759,6 +764,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d6dafc854908ff5da46ff3f8f473c6984119a2876a383a860246dd7841a868"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,7 +786,7 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide",
+ "miniz_oxide 0.5.3",
 ]
 
 [[package]]
@@ -1696,8 +1710,22 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "indexmap"
 version = "2.1.0"
+=======
+name = "inflate"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+>>>>>>> 47bfb12 (iconforge beta)
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
@@ -1979,6 +2007,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+ "simd-adler32",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -2374,7 +2412,11 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
+<<<<<<< HEAD
  "miniz_oxide",
+=======
+ "miniz_oxide 0.7.1",
+>>>>>>> 47bfb12 (iconforge beta)
 ]
 
 [[package]]
@@ -2767,7 +2809,6 @@ dependencies = [
  "gix",
  "hex",
  "image",
- "lazy_static",
  "md-5",
  "mysql",
  "noise",
@@ -2786,7 +2827,12 @@ dependencies = [
  "sha-1",
  "sha2",
  "thiserror",
+<<<<<<< HEAD
  "toml 0.8.8",
+=======
+ "toml",
+ "tracy_full",
+>>>>>>> 47bfb12 (iconforge beta)
  "twox-hash",
  "url",
  "zip",
@@ -2821,6 +2867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+<<<<<<< HEAD
 name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,6 +2878,14 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
+=======
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+>>>>>>> 47bfb12 (iconforge beta)
 ]
 
 [[package]]
@@ -3063,6 +3118,12 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"
@@ -3406,6 +3467,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db0b1cc1bb12a70457300d9affc07acb587390d971a796dac2f4d9bca8df776"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "tracy_full"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01aaff24a62ad715d80adcf28e47c228dbed3d6285fb85b55bfd9eb47fda4df"
+dependencies = [
+ "once_cell",
+ "rustc_version",
+ "tracy-client-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,8 @@ iconforge = [
     "tracy_full",
     "jobs",
     "once_cell",
-    "dashmap"
+    "dashmap",
+    "hash",
 ]
 redis_pubsub = ["flume", "redis", "serde", "serde_json"]
 redis_reliablequeue = ["flume", "redis", "serde", "serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ dbpnoise = { version = "0.1.2", optional = true }
 pathfinding = { version = "4.4", optional = true }
 num-integer = { version = "0.1.45", optional = true }
 dmi = { version = "0.3.1", optional = true }
+tracy_full =  { version = "1.6.1", optional = true}
 
 [features]
 default = [
@@ -134,6 +135,7 @@ hash = [
     "serde_json",
 ]
 pathfinder = ["num-integer", "pathfinding", "serde", "serde_json"]
+iconforge = ["serde", "serde_json", "png", "image", "dep:dmi", "rayon", "tracy_full", "jobs", "once_cell"]
 redis_pubsub = ["flume", "redis", "serde", "serde_json"]
 redis_reliablequeue = ["flume", "redis", "serde", "serde_json"]
 unzip = ["zip", "jobs"]
@@ -148,3 +150,16 @@ jobs = ["flume"]
 
 [dev-dependencies]
 regex = "1"
+
+# DEV ONLY. REMOVE THIS LATER
+[profile.dev.package.dmi]
+opt-level = 3
+
+[profile.dev.package.image]
+opt-level = 3
+
+[profile.dev.package.serde]
+opt-level = 3
+
+[profile.dev.package.serde_json]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ all = [
     "file",
     "git",
     "http",
+    "iconforge",
     "json",
     "log",
     "noise",
@@ -135,7 +136,6 @@ hash = [
     "serde",
     "serde_json",
 ]
-pathfinder = ["num-integer", "pathfinding", "serde", "serde_json"]
 iconforge = [
     "serde",
     "serde_json",
@@ -149,6 +149,7 @@ iconforge = [
     "dashmap",
     "hash",
 ]
+pathfinder = ["num-integer", "pathfinding", "serde", "serde_json"]
 redis_pubsub = ["flume", "redis", "serde", "serde_json"]
 redis_reliablequeue = ["flume", "redis", "serde", "serde_json"]
 unzip = ["zip", "jobs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ pathfinding = { version = "4.4", optional = true }
 num-integer = { version = "0.1.45", optional = true }
 dmi = { version = "0.3.1", optional = true }
 tracy_full =  { version = "1.6.1", optional = true}
+#tracy_full =  { version = "1.6.1", optional = true, features = ["enable"]}
 
 [features]
 default = [
@@ -135,7 +136,18 @@ hash = [
     "serde_json",
 ]
 pathfinder = ["num-integer", "pathfinding", "serde", "serde_json"]
-iconforge = ["serde", "serde_json", "png", "image", "dep:dmi", "rayon", "tracy_full", "jobs", "once_cell"]
+iconforge = [
+    "serde",
+    "serde_json",
+    "png",
+    "image",
+    "dep:dmi",
+    "rayon",
+    "tracy_full",
+    "jobs",
+    "once_cell",
+    "dashmap"
+]
 redis_pubsub = ["flume", "redis", "serde", "serde_json"]
 redis_reliablequeue = ["flume", "redis", "serde", "serde_json"]
 unzip = ["zip", "jobs"]
@@ -150,16 +162,3 @@ jobs = ["flume"]
 
 [dev-dependencies]
 regex = "1"
-
-# DEV ONLY. REMOVE THIS LATER
-[profile.dev.package.dmi]
-opt-level = 3
-
-[profile.dev.package.image]
-opt-level = 3
-
-[profile.dev.package.serde]
-opt-level = 3
-
-[profile.dev.package.serde_json]
-opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ serde_json = { version = "1.0", optional = true }
 lazy_static = { version = "1.4", optional = true }
 once_cell = { version = "1.19", optional = true }
 mysql = { version = "24.0", default_features = false, optional = true }
-dashmap = { version = "5.5", optional = true }
+dashmap = { version = "5.5", optional = true, features = ["rayon", "serde"]}
 zip = { version = "0.6", optional = true }
 rand = { version = "0.8", optional = true }
 toml-dep = { version = "0.8.8", package = "toml", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,9 @@ rayon = { version = "1.8", optional = true }
 dbpnoise = { version = "0.1.2", optional = true }
 pathfinding = { version = "4.4", optional = true }
 num-integer = { version = "0.1.45", optional = true }
-dmi = { version = "0.3.3", optional = true }
-tracy_full = { version = "1.6.1", optional = true }
-#tracy_full = { version = "1.6.1", optional = true, features = ["enable"] }
+dmi = { version = "0.3.4", optional = true }
+#tracy_full = { version = "1.6.1", optional = true }
+tracy_full = { version = "1.6.1", optional = true, features = ["enable"] }
 
 [features]
 default = [
@@ -139,6 +139,7 @@ hash = [
 iconforge = [
     "dashmap",
     "dep:dmi",
+    "hash",
     "image",
     "jobs",
     "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ rayon = { version = "1.8", optional = true }
 dbpnoise = { version = "0.1.2", optional = true }
 pathfinding = { version = "4.4", optional = true }
 num-integer = { version = "0.1.45", optional = true }
-dmi = { version = "0.3.1", optional = true }
+dmi = { version = "0.3.3", optional = true }
 tracy_full =  { version = "1.6.1", optional = true}
 #tracy_full =  { version = "1.6.1", optional = true, features = ["enable"]}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,7 @@ dbpnoise = { version = "0.1.2", optional = true }
 pathfinding = { version = "4.4", optional = true }
 num-integer = { version = "0.1.45", optional = true }
 dmi = { version = "0.3.4", optional = true }
-#tracy_full = { version = "1.6.1", optional = true }
-tracy_full = { version = "1.6.1", optional = true, features = ["enable"] }
+tracy_full = { version = "1.6.1", optional = true }
 
 [features]
 default = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ serde_json = { version = "1.0", optional = true }
 lazy_static = { version = "1.4", optional = true }
 once_cell = { version = "1.19", optional = true }
 mysql = { version = "24.0", default_features = false, optional = true }
-dashmap = { version = "5.5", optional = true, features = ["rayon", "serde"]}
+dashmap = { version = "5.5", optional = true, features = ["rayon", "serde"] }
 zip = { version = "0.6", optional = true }
 rand = { version = "0.8", optional = true }
 toml-dep = { version = "0.8.8", package = "toml", optional = true }
@@ -63,8 +63,8 @@ dbpnoise = { version = "0.1.2", optional = true }
 pathfinding = { version = "4.4", optional = true }
 num-integer = { version = "0.1.45", optional = true }
 dmi = { version = "0.3.3", optional = true }
-tracy_full =  { version = "1.6.1", optional = true}
-#tracy_full =  { version = "1.6.1", optional = true, features = ["enable"]}
+tracy_full = { version = "1.6.1", optional = true }
+#tracy_full = { version = "1.6.1", optional = true, features = ["enable"] }
 
 [features]
 default = [
@@ -137,17 +137,17 @@ hash = [
     "serde_json",
 ]
 iconforge = [
-    "serde",
-    "serde_json",
-    "png",
-    "image",
+    "dashmap",
     "dep:dmi",
-    "rayon",
-    "tracy_full",
+    "image",
     "jobs",
     "once_cell",
-    "dashmap",
-    "hash",
+    "png",
+    "rayon",
+    "serde",
+    "serde_json",
+    "tracy_full",
+    "twox-hash",
 ]
 pathfinder = ["num-integer", "pathfinding", "serde", "serde_json"]
 redis_pubsub = ["flume", "redis", "serde", "serde_json"]

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The default features are:
 Additional features are:
 * batchnoise: Discrete Batched Perlin-like Noise, fast and multi-threaded - sent over once instead of having to query for every tile.
 * hash: Faster replacement for `md5`, support for SHA-1, SHA-256, and SHA-512. Requires OpenSSL on Linux.
+* iconforge: A much faster replacement for the spritesheet generation system used by [/tg/station].
 * pathfinder: An a* pathfinder used for finding the shortest path in a static node map. Not to be used for a non-static map.
 * redis_pubsub: Library for sending and receiving messages through Redis.
 * redis_reliablequeue: Library for using a reliable queue pattern through Redis.

--- a/dmsrc/iconforge.dm
+++ b/dmsrc/iconforge.dm
@@ -18,10 +18,10 @@
 ///     ...,
 /// )
 /// TRANSFORM_OBJECT format:
-/// list("type" = "BlendColor", "color" = "#ff0000", "blend_mode" = ICON_MULTIPLY)
-/// list("type" = "BlendIcon", "icon" = [SPRITE_OBJECT], "blend_mode" = ICON_OVERLAY)
-/// list("type" = "Scale", "width" = 32, "height" = 32)
-/// list("type" = "Crop", "x1" = 1, "y1" = 1, "x2" = 32, "y2" = 32) // (BYOND icons index from 1,1 to the upper bound, inclusive)
+/// list("type" = RUSTG_ICONFORGE_BLEND_COLOR, "color" = "#ff0000", "blend_mode" = ICON_MULTIPLY)
+/// list("type" = RUSTG_ICONFORGE_BLEND_ICON, "icon" = [SPRITE_OBJECT], "blend_mode" = ICON_OVERLAY)
+/// list("type" = RUSTG_ICONFORGE_SCALE, "width" = 32, "height" = 32)
+/// list("type" = RUSTG_ICONFORGE_CROP, "x1" = 1, "y1" = 1, "x2" = 32, "y2" = 32) // (BYOND icons index from 1,1 to the upper bound, inclusive)
 ///
 /// Returns a SpritesheetResult as JSON, containing fields:
 /// list(
@@ -35,7 +35,7 @@
 #define rustg_iconforge_generate(file_path, spritesheet_name, sprites, hash_icons) RUSTG_CALL(RUST_G, "iconforge_generate")(file_path, spritesheet_name, sprites, "[hash_icons]")
 /// Returns a job_id for use with rustg_iconforge_check()
 #define rustg_iconforge_generate_async(file_path, spritesheet_name, sprites, hash_icons) RUSTG_CALL(RUST_G, "iconforge_generate_async")(file_path, spritesheet_name, sprites, "[hash_icons]")
-/// Returns the status of a job_id
+/// Returns the status of an async job_id, or its result if it is completed. See RUSTG_JOB DEFINEs.
 #define rustg_iconforge_check(job_id) RUSTG_CALL(RUST_G, "iconforge_check")("[job_id]")
 /// Clears all cached DMIs and images, freeing up memory.
 /// This should be used after spritesheets are done being generated.

--- a/dmsrc/iconforge.dm
+++ b/dmsrc/iconforge.dm
@@ -1,21 +1,27 @@
 /// Generates a spritesheet at: [file_path][spritesheet_name]_[size_id].png
 /// Spritesheet will contain all sprites listed within "sprites".
-/// Sprite object format: list(
-/// 	icon_file = 'icons/path_to/an_icon.dmi',
-/// 	icon_state = "some_icon_state",
-/// 	dir = SOUTH,
-/// 	frame = 1,
-/// 	transform = list(transform_object, ...)
-///	)
-/// transform_object format:
-/// list("type" = "Color", "color" = "#ff0000", "blend_mode" = ICON_MULTIPLY)
-/// list("type" = "Icon", "icon" = sprite_object, "blend_mode" = ICON_OVERLAY)
+/// "sprites" format:
+/// list(
+///     "sprite_name" = list(
+///         icon_file = 'icons/path_to/an_icon.dmi',
+///         icon_state = "some_icon_state",
+///         dir = SOUTH,
+///         frame = 1,
+///         transform = list([TRANSFORM_OBJECT], ...)
+///     ),
+///     ...,
+/// )
+/// TRANSFORM_OBJECT format:
+/// list("type" = "BlendColor", "color" = "#ff0000", "blend_mode" = ICON_MULTIPLY)
+/// list("type" = "BlendIcon", "icon" = sprite_object, "blend_mode" = ICON_OVERLAY)
 /// list("type" = "Scale", "width" = 32, "height" = 32)
 /// list("type" = "Crop", "x1" = 0, "y1" = 0, "x2" = 32, "y2" = 32)
 /// Returns a SpritesheetResult as JSON, containing fields:
-///		sizes: list("32x32", "64x64", ...etc)
-///		sprites: list("sprite_name" = list("size_id" = "32x32", "position" = 0), ...)
-///		error: A string, empty if there were no errors.
+/// list(
+///     "sizes" = list("32x32", "64x64", ...etc)
+///     "sprites" = list("sprite_name" = list("size_id" = "32x32", "position" = 0), ...)
+///     "error" = "[A string, empty if there were no errors.]"
+/// )
 /// In the event of an unrecoverable error, where the spritesheet could not even generate, returns a string containing the error.
 #define rustg_iconforge_generate(file_path, spritesheet_name, sprites) RUSTG_CALL(RUST_G, "iconforge_generate")(file_path, spritesheet_name, sprites)
 /// Returns a job_id for use with rustg_iconforge_check()

--- a/dmsrc/iconforge.dm
+++ b/dmsrc/iconforge.dm
@@ -24,4 +24,4 @@
 #define rustg_iconforge_check(job_id) RUSTG_CALL(RUST_G, "iconforge_check")("[job_id]")
 /// Clears all cached DMIs and images, freeing up memory.
 /// This should be used after spritesheets are done being generated.
-#define rustg_iconforge_cleanup() RUSTG_CALL(RUST_G, "iconforge_cleanup")()
+#define rustg_iconforge_cleanup RUSTG_CALL(RUST_G, "iconforge_cleanup")

--- a/dmsrc/iconforge.dm
+++ b/dmsrc/iconforge.dm
@@ -1,8 +1,14 @@
 /// Generates a spritesheet at: [file_path][spritesheet_name]_[size_id].png
+/// The resulting spritesheet arranges icons in a random order, with the position being denoted in the "sprites" return value.
+/// All icons have the same y coordinate, and their x coordinate is equal to `icon_width * position`.
+///
+/// hash_icons is a boolean (0 or 1), and determines if the generator will spend time creating hashes for the output field dmi_hashes.
+/// These hashes can be heplful for 'smart' caching (see rustg_iconforge_cache_valid), but require extra computation.
+///
 /// Spritesheet will contain all sprites listed within "sprites".
 /// "sprites" format:
 /// list(
-///     "sprite_name" = list(
+///     "sprite_name" = list( // <--- this list is a [SPRITE_OBJECT]
 ///         icon_file = 'icons/path_to/an_icon.dmi',
 ///         icon_state = "some_icon_state",
 ///         dir = SOUTH,
@@ -13,21 +19,41 @@
 /// )
 /// TRANSFORM_OBJECT format:
 /// list("type" = "BlendColor", "color" = "#ff0000", "blend_mode" = ICON_MULTIPLY)
-/// list("type" = "BlendIcon", "icon" = sprite_object, "blend_mode" = ICON_OVERLAY)
+/// list("type" = "BlendIcon", "icon" = [SPRITE_OBJECT], "blend_mode" = ICON_OVERLAY)
 /// list("type" = "Scale", "width" = 32, "height" = 32)
 /// list("type" = "Crop", "x1" = 0, "y1" = 0, "x2" = 32, "y2" = 32)
+///
 /// Returns a SpritesheetResult as JSON, containing fields:
 /// list(
-///     "sizes" = list("32x32", "64x64", ...etc)
-///     "sprites" = list("sprite_name" = list("size_id" = "32x32", "position" = 0), ...)
+///     "sizes" = list("32x32", "64x64", ...),
+///     "sprites" = list("sprite_name" = list("size_id" = "32x32", "position" = 0), ...),
+///     "dmi_hashes" = list("icons/path_to/an_icon.dmi" = "d6325c5b4304fb03", ...),
+///     "sprites_hash" = "a2015e5ff403fb5c", // This is the xxh64 hash of the INPUT field "sprites".
 ///     "error" = "[A string, empty if there were no errors.]"
 /// )
-/// In the event of an unrecoverable error, where the spritesheet could not even generate, returns a string containing the error.
-#define rustg_iconforge_generate(file_path, spritesheet_name, sprites) RUSTG_CALL(RUST_G, "iconforge_generate")(file_path, spritesheet_name, sprites)
+/// In the case of an unrecoverable panic from within Rust, this function ONLY returns a string containing the error.
+#define rustg_iconforge_generate(file_path, spritesheet_name, sprites, hash_icons) RUSTG_CALL(RUST_G, "iconforge_generate")(file_path, spritesheet_name, sprites, "[hash_icons]")
 /// Returns a job_id for use with rustg_iconforge_check()
-#define rustg_iconforge_generate_async(file_path, spritesheet_name, sprites) RUSTG_CALL(RUST_G, "iconforge_generate_async")(file_path, spritesheet_name, sprites)
+#define rustg_iconforge_generate_async(file_path, spritesheet_name, sprites, hash_icons) RUSTG_CALL(RUST_G, "iconforge_generate_async")(file_path, spritesheet_name, sprites, "[hash_icons]")
 /// Returns the status of a job_id
 #define rustg_iconforge_check(job_id) RUSTG_CALL(RUST_G, "iconforge_check")("[job_id]")
 /// Clears all cached DMIs and images, freeing up memory.
 /// This should be used after spritesheets are done being generated.
 #define rustg_iconforge_cleanup RUSTG_CALL(RUST_G, "iconforge_cleanup")
+/// Takes in a set of hashes, generate inputs, and DMI filepaths, and compares them to determine cache validity.
+/// input_hash: xxh64 hash of "sprites" from the cache.
+/// dmi_hashes: xxh64 hashes of the DMIs in a spritesheet, given by `rustg_iconforge_generate` with `hash_icons` enabled. From the cache.
+/// sprites: The new input that will be passed to rustg_iconforge_generate().
+/// Returns a CacheResult with the following structure: list(
+///     "result": "1" (if cache is valid) or "0" (if cache is invalid)
+///     "fail_reason": "" (emtpy string if valid, otherwise a string containing the invalidation reason or an error with ERROR: prefixed.)
+/// )
+/// In the case of an unrecoverable panic from within Rust, this function ONLY returns a string containing the error.
+#define rustg_iconforge_cache_valid(input_hash, dmi_hashes, sprites) RUSTG_CALL(RUST_G, "iconforge_cache_valid")(input_hash, dmi_hashes, sprites)
+/// Returns a job_id for use with rustg_iconforge_check()
+#define rustg_iconforge_cache_valid_async(input_hash, dmi_hashes, sprites) RUSTG_CALL(RUST_G, "iconforge_cache_valid_async")(input_hash, dmi_hashes, sprites)
+
+#define RUSTG_ICONFORGE_BLEND_COLOR "BlendColor"
+#define RUSTG_ICONFORGE_BLEND_ICON "BlendIcon"
+#define RUSTG_ICONFORGE_CROP "Crop"
+#define RUSTG_ICONFORGE_SCALE "Scale"

--- a/dmsrc/iconforge.dm
+++ b/dmsrc/iconforge.dm
@@ -1,3 +1,27 @@
+/// Generates a spritesheet at: [file_path][spritesheet_name]_[size_id].png
+/// Spritesheet will contain all sprites listed within "sprites".
+/// Sprite object format: list(
+/// 	icon_file = 'icons/path_to/an_icon.dmi',
+/// 	icon_state = "some_icon_state",
+/// 	dir = SOUTH,
+/// 	frame = 1,
+/// 	transform = list(transform_object, ...)
+///	)
+/// transform_object format:
+/// list("type" = "Color", "color" = "#ff0000", "blend_mode" = ICON_MULTIPLY)
+/// list("type" = "Icon", "icon" = sprite_object, "blend_mode" = ICON_OVERLAY)
+/// list("type" = "Scale", "width" = 32, "height" = 32)
+/// list("type" = "Crop", "x1" = 0, "y1" = 0, "x2" = 32, "y2" = 32)
+/// Returns a SpritesheetResult as JSON, containing fields:
+///		sizes: list("32x32", "64x64", ...etc)
+///		sprites: list("sprite_name" = list("size_id" = "32x32", "position" = 0), ...)
+///		error: A string, empty if there were no errors.
+/// In the event of an unrecoverable error, where the spritesheet could not even generate, returns a string containing the error.
 #define rustg_iconforge_generate(file_path, spritesheet_name, sprites) RUSTG_CALL(RUST_G, "iconforge_generate")(file_path, spritesheet_name, sprites)
+/// Returns a job_id for use with rustg_iconforge_check()
 #define rustg_iconforge_generate_async(file_path, spritesheet_name, sprites) RUSTG_CALL(RUST_G, "iconforge_generate_async")(file_path, spritesheet_name, sprites)
+/// Returns the status of a job_id
 #define rustg_iconforge_check(job_id) RUSTG_CALL(RUST_G, "iconforge_check")("[job_id]")
+/// Clears all cached DMIs and images, freeing up memory.
+/// This should be used after spritesheets are done being generated.
+#define rustg_iconforge_cleanup() RUSTG_CALL(RUST_G, "iconforge_cleanup")()

--- a/dmsrc/iconforge.dm
+++ b/dmsrc/iconforge.dm
@@ -21,7 +21,7 @@
 /// list("type" = "BlendColor", "color" = "#ff0000", "blend_mode" = ICON_MULTIPLY)
 /// list("type" = "BlendIcon", "icon" = [SPRITE_OBJECT], "blend_mode" = ICON_OVERLAY)
 /// list("type" = "Scale", "width" = 32, "height" = 32)
-/// list("type" = "Crop", "x1" = 0, "y1" = 0, "x2" = 32, "y2" = 32)
+/// list("type" = "Crop", "x1" = 1, "y1" = 1, "x2" = 32, "y2" = 32) // (BYOND icons index from 1,1 to the upper bound, inclusive)
 ///
 /// Returns a SpritesheetResult as JSON, containing fields:
 /// list(

--- a/dmsrc/iconforge.dm
+++ b/dmsrc/iconforge.dm
@@ -1,0 +1,3 @@
+#define rustg_iconforge_generate(file_path, spritesheet_name, sprites) RUSTG_CALL(RUST_G, "iconforge_generate")(file_path, spritesheet_name, sprites)
+#define rustg_iconforge_generate_async(file_path, spritesheet_name, sprites) RUSTG_CALL(RUST_G, "iconforge_generate_async")(file_path, spritesheet_name, sprites)
+#define rustg_iconforge_check(job_id) RUSTG_CALL(RUST_G, "iconforge_check")("[job_id]")

--- a/src/byond.rs
+++ b/src/byond.rs
@@ -97,7 +97,6 @@ pub fn set_panic_hook() {
     SET_HOOK.call_once(|| {
         std::panic::set_hook(Box::new(|panic_info| {
             let mut file = OpenOptions::new()
-                .write(true)
                 .append(true)
                 .create(true)
                 .open("rustg-panic.log")

--- a/src/byond.rs
+++ b/src/byond.rs
@@ -124,7 +124,7 @@ pub fn catch_panic<F>(f: F) -> Result<String, Error>
 where
     F: FnOnce() -> Result<String, Error> + std::panic::UnwindSafe,
 {
-    match std::panic::catch_unwind(|| f()) {
+    match std::panic::catch_unwind(f) {
         Ok(o) => o,
         Err(e) => {
             let message: Option<String> = e

--- a/src/byond.rs
+++ b/src/byond.rs
@@ -112,7 +112,7 @@ pub fn set_panic_hook() {
             )
             .expect("Failed to extract error payload");
             file.write_all(Backtrace::capture().to_string().as_bytes())
-                    .expect("Failed to extract error backtrace");
+                .expect("Failed to extract error backtrace");
         }))
     });
 }

--- a/src/byond.rs
+++ b/src/byond.rs
@@ -91,7 +91,7 @@ byond_fn!(
     }
 );
 
-// Print any panics before exiting.
+/// Print any panics before exiting.
 pub fn set_panic_hook() {
     SET_HOOK.call_once(|| {
         std::panic::set_hook(Box::new(|panic_info| {
@@ -101,8 +101,6 @@ pub fn set_panic_hook() {
                 .create(true)
                 .open("rustg-panic.log")
                 .unwrap();
-            file.write_all(Backtrace::capture().to_string().as_bytes())
-                .expect("Failed to extract error backtrace");
             file.write_all(
                 panic_info
                     .payload()
@@ -113,6 +111,8 @@ pub fn set_panic_hook() {
                     .as_bytes(),
             )
             .expect("Failed to extract error payload");
+            file.write_all(Backtrace::capture().to_string().as_bytes())
+                    .expect("Failed to extract error backtrace");
         }))
     });
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,8 +62,8 @@ pub enum Error {
     #[error("Unable to decode hex value.")]
     HexDecode,
     #[cfg(feature = "iconforge")]
-    #[error("IconState error: {0}")]
-    IconState(String),
+    #[error("IconForge error: {0}")]
+    IconForge(String),
 }
 
 impl From<Utf8Error> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,9 @@ pub enum Error {
     #[cfg(feature = "hash")]
     #[error("Unable to decode hex value.")]
     HexDecode,
+    #[cfg(feature = "iconforge")]
+    #[error("IconState error: {0}")]
+    IconState(String),
 }
 
 impl From<Utf8Error> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,6 +64,8 @@ pub enum Error {
     #[cfg(feature = "iconforge")]
     #[error("IconForge error: {0}")]
     IconForge(String),
+    #[error("Panic during function execution: {0}")]
+    Panic(String),
 }
 
 impl From<Utf8Error> for Error {

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -70,17 +70,22 @@ fn hash_algorithm<B: AsRef<[u8]>>(name: &str, bytes: B) -> Result<String> {
             let mut hasher = XxHash64::with_seed(XXHASH_SEED);
             hasher.write(bytes.as_ref());
             Ok(format!("{:x}", hasher.finish()))
+        },
+        "xxh64_fixed" => {
+            let mut hasher = XxHash64::with_seed(17479268743136991876);
+            hasher.write(bytes.as_ref());
+            Ok(format!("{:x}", hasher.finish()))
         }
         "base64" => Ok(base64::prelude::BASE64_STANDARD.encode(bytes.as_ref())),
         _ => Err(Error::InvalidAlgorithm),
     }
 }
 
-fn string_hash(algorithm: &str, string: &str) -> Result<String> {
+pub fn string_hash(algorithm: &str, string: &str) -> Result<String> {
     hash_algorithm(algorithm, string)
 }
 
-fn file_hash(algorithm: &str, path: &str) -> Result<String> {
+pub fn file_hash(algorithm: &str, path: &str) -> Result<String> {
     let mut bytes: Vec<u8> = Vec::new();
     let mut file = BufReader::new(File::open(path)?);
     file.read_to_end(&mut bytes)?;

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -72,7 +72,7 @@ fn hash_algorithm<B: AsRef<[u8]>>(name: &str, bytes: B) -> Result<String> {
             Ok(format!("{:x}", hasher.finish()))
         }
         "xxh64_fixed" => {
-            let mut hasher = XxHash64::with_seed(17479268743136991876);
+            let mut hasher = XxHash64::with_seed(17479268743136991876); // this seed is just a random number that should stay the same between builds and runs
             hasher.write(bytes.as_ref());
             Ok(format!("{:x}", hasher.finish()))
         }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -76,11 +76,11 @@ fn hash_algorithm<B: AsRef<[u8]>>(name: &str, bytes: B) -> Result<String> {
     }
 }
 
-fn string_hash(algorithm: &str, string: &str) -> Result<String> {
+pub fn string_hash(algorithm: &str, string: &str) -> Result<String> {
     hash_algorithm(algorithm, string)
 }
 
-fn file_hash(algorithm: &str, path: &str) -> Result<String> {
+pub fn file_hash(algorithm: &str, path: &str) -> Result<String> {
     let mut bytes: Vec<u8> = Vec::new();
     let mut file = BufReader::new(File::open(path)?);
     file.read_to_end(&mut bytes)?;

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -76,11 +76,11 @@ fn hash_algorithm<B: AsRef<[u8]>>(name: &str, bytes: B) -> Result<String> {
     }
 }
 
-pub fn string_hash(algorithm: &str, string: &str) -> Result<String> {
+fn string_hash(algorithm: &str, string: &str) -> Result<String> {
     hash_algorithm(algorithm, string)
 }
 
-pub fn file_hash(algorithm: &str, path: &str) -> Result<String> {
+fn file_hash(algorithm: &str, path: &str) -> Result<String> {
     let mut bytes: Vec<u8> = Vec::new();
     let mut file = BufReader::new(File::open(path)?);
     file.read_to_end(&mut bytes)?;

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -70,7 +70,7 @@ fn hash_algorithm<B: AsRef<[u8]>>(name: &str, bytes: B) -> Result<String> {
             let mut hasher = XxHash64::with_seed(XXHASH_SEED);
             hasher.write(bytes.as_ref());
             Ok(format!("{:x}", hasher.finish()))
-        },
+        }
         "xxh64_fixed" => {
             let mut hasher = XxHash64::with_seed(17479268743136991876);
             hasher.write(bytes.as_ref());

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -5,8 +5,8 @@ use crate::hash::string_hash;
 use crate::jobs;
 use dashmap::DashMap;
 use dmi::{
-    icon::{Icon, IconState},
     dirs::Dirs,
+    icon::{Icon, IconState},
 };
 use image::{DynamicImage, GenericImage, GenericImageView, ImageBuffer, Pixel};
 use once_cell::sync::Lazy;

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -956,7 +956,7 @@ fn transform_image(image: &mut RgbaImage, transform: &Transform) -> Result<(), S
                         image::Rgba([0, 0, 0, 0])
                     });
 
-                image::imageops::overlay(&mut blank_img, image, x_offset as i64, y_offset as i64);
+                image::imageops::replace(&mut blank_img, image, x_offset as i64, y_offset as i64);
                 *image = image::imageops::crop_imm(
                     &blank_img,
                     x1 as u32,
@@ -1055,7 +1055,12 @@ impl Rgba {
             3 => Rgba::map_each_a(
                 self,
                 other_color,
-                |c1, c2, _c1_a, c2_a| c1 + (c2 - c1) * c2_a / 255.0,
+                |c1, c2, c1_a, c2_a| {
+                    if c1_a == 0.0 {
+                        return c2;
+                    }
+                    c1 + (c2 - c1) * c2_a / 255.0
+                },
                 |a1, a2| {
                     let high = f32::max(a1, a2);
                     let low = f32::min(a1, a2);
@@ -1065,7 +1070,12 @@ impl Rgba {
             6 => Rgba::map_each_a(
                 other_color,
                 self,
-                |c1, c2, _c1_a, c2_a| c1 + (c2 - c1) * c2_a / 255.0,
+                |c1, c2, c1_a, c2_a| {
+                    if c1_a == 0.0 {
+                        return c2;
+                    }
+                    c1 + (c2 - c1) * c2_a / 255.0
+                },
                 |a1, a2| {
                     let high = f32::max(a1, a2);
                     let low = f32::min(a1, a2);

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -280,7 +280,7 @@ fn cache_valid(input_hash: &str, dmi_hashes_in: &str, sprites_in: &str) -> Resul
                             if fail_reason.read().unwrap().is_some() {
                                 return;
                             }
-                            *fail_reason.write().unwrap() = Some(format!("ERROR: Error while hashing dmi_path '{}': {}", dmi_path, err.to_string()));
+                            *fail_reason.write().unwrap() = Some(format!("ERROR: Error while hashing dmi_path '{}': {}", dmi_path, err));
                         }
                     }
                 }

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -1045,7 +1045,7 @@ impl Rgba {
     fn blend(&self, other_color: &Rgba, blend_mode: u8) -> Rgba {
         match blend_mode {
             0 => Rgba::map_each(self, other_color, |c1, c2| c1 + c2, f32::min),
-            1 => Rgba::map_each(self, other_color, |c1, c2| c2 - c1, f32::min),
+            1 => Rgba::map_each(self, other_color, |c1, c2| c1 - c2, f32::min),
             2 => Rgba::map_each(
                 self,
                 other_color,

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -361,7 +361,7 @@ fn generate_spritesheet(
             .into_par_iter()
             .for_each(|icon| match icon_to_dmi(icon) {
                 Ok(_) => {
-                    if hash_icons {
+                    if hash_icons && !dmi_hashes.contains_key(&icon.icon_file) {
                         zone!("hash_dmi");
                         match file_hash("xxh64_fixed", &icon.icon_file) {
                             Ok(hash) => {

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -273,7 +273,8 @@ fn generate_spritesheet(
                     return;
                 }
             };
-            let unique_icons = DashMap::<Vec<Transform>, &IconObject>::new();
+            let mut no_transforms = Option::<&IconObject>::None;
+            let unique_icons = DashMap::<String, &IconObject>::new();
             {
                 zone!("map_unique");
                 icons.iter().for_each(|(_, icon)| {
@@ -281,13 +282,15 @@ fn generate_spritesheet(
                     // Since all icons share the same 'base'.
                     // Also check to see if the icon is already cached. If so, we can ignore this transform chain.
                     if !ICON_STATES.contains_key(&icon.icon_hash_input) {
-                        // TODO, try to make a faster hash for this. Can probably generate a unique hash for transforms during the IO conversion step.
-                        unique_icons.insert(icon.transform.clone(), icon);
+                        unique_icons.insert(icon.icon_hash_input.clone(), icon);
+                    }
+                    if icon.transform.is_empty() {
+                        no_transforms = Some(icon);
                     }
                 });
             }
-            if let Some(entry) = unique_icons.get(&Vec::new()) {
-                if let Err(err) = return_image(base_image.clone(), entry.value()) {
+            if let Some(entry) = no_transforms {
+                if let Err(err) = return_image(base_image.clone(), entry) {
                     error.lock().unwrap().push(err.to_string());
                 }
             }

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -364,7 +364,7 @@ fn transform_image(image_in: DynamicImage, icon: &IconObject, sprite_name: &Stri
                 }
                 let mut color2: [u8; 4] = [0, 0, 0, 255];
                 if let Err(err) = hex::decode_to_slice(hex, &mut color2) {
-                    error.push(format!("Decoding hex color {} failed: {}", color, err.to_string()));
+                    error.push(format!("Decoding hex color {} failed: {}", color, err));
                 }
                 for x in 0..image.width() {
                     for y in 0..image.height() {

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -15,12 +15,26 @@ use serde::{Serialize, Deserialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tracy_full::{zone, frame};
-use once_cell::sync::OnceCell;
+use once_cell::sync::Lazy;
+static ICON_FILES: Lazy<Mutex<HashMap<String, Icon>>> = Lazy::new(Mutex::default);
+static ICON_STATES: Lazy<Mutex<HashMap<String, &mut DynamicImage>>> = Lazy::new(Mutex::default);
 
-fn icon_file_to_icon() -> &'static Mutex<HashMap<String, Icon>> {
-    static INSTANCE: OnceCell<Mutex<HashMap<String, Icon>>> = OnceCell::new();
-    INSTANCE.get_or_init(|| Mutex::new(HashMap::new()))
-}
+const SOUTH: u8 = 2;
+const NORTH: u8 = 1;
+const EAST: u8 = 4;
+const WEST: u8 = 8;
+const FOUR_DIRS: [u8; 4] = [SOUTH, NORTH, EAST, WEST];
+const SOUTHEAST: u8 = SOUTH | EAST; // 6
+const SOUTHWEST: u8 = SOUTH | WEST; // 10
+const NORTHEAST: u8 = NORTH | EAST; // 5
+const NORTHWEST: u8 = NORTH | WEST; // 9
+const EIGHT_DIRS: [u8; 8] = [SOUTH, NORTH, EAST, WEST, SOUTHEAST, SOUTHWEST, NORTHEAST, NORTHWEST];
+
+const DMI_ORDERING: [u8; 8] = EIGHT_DIRS;
+// This is an array mapping the DIR number from above to a position in DMIs, such that DIR_TO_INDEX[DIR] = DMI_ORDERING.indexof(DIR)
+// 255 is invalid.
+const DIR_TO_INDEX: [u8; 11] = [255, 1, 0, 255, 2, 6, 4, 255, 3, 7, 5];
+
 
 byond_fn!(fn iconforge_generate(file_path, spritesheet_name, sprites) {
     catch_panic(file_path, spritesheet_name, sprites).err()
@@ -28,9 +42,10 @@ byond_fn!(fn iconforge_generate(file_path, spritesheet_name, sprites) {
 
 
 byond_fn!(fn iconforge_generate_async(file_path, spritesheet_name, sprites) {
-    let file_path = file_path.to_owned();
-    let spritesheet_name = spritesheet_name.to_owned();
-    let sprites = sprites.to_owned();
+    // Take ownership before passing
+    let file_path = file_path;
+    let spritesheet_name = spritesheet_name;
+    let sprites = sprites;
     Some(jobs::start(move || {
         match catch_panic(&file_path, &spritesheet_name, &sprites) {
             Ok(o) => o.to_string(),
@@ -64,6 +79,16 @@ struct IconObject {
 	frame: u32,
 	moving: u8,
 	transform: Vec<Transform>
+}
+
+trait IcoString {
+    fn to_icostring() -> String;
+}
+
+impl IcoString for IconObject {
+    fn to_icostring() -> String {
+        return "".to_string(); // TODO implement this as as unique ID. Transforms need another trait
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -113,81 +138,35 @@ fn generate_spritesheet(file_path: &str, spritesheet_name: &str, sprites: &str) 
 
     let error: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
 
-    let size_to_images: Arc<Mutex<HashMap<String, Vec<DynamicImage>>>> = Arc::new(Mutex::new(HashMap::new()));
+    let size_to_images: Arc<Mutex<HashMap<String, Vec<&mut DynamicImage>>>> = Arc::new(Mutex::new(HashMap::new()));
     let sprites_map: HashMap<String, IconObject> = serde_json::from_str::<HashMap<String, IconObject>>(sprites)?;
     let sprites_objects: Arc<Mutex<HashMap<String, SpritesheetEntry>>> = Arc::new(Mutex::new(HashMap::new()));
 
+    // Pre-load all the DMIs now.
     sprites_map.par_iter().for_each(|sprite_entry| {
         zone!("sprite_to_icons");
         let (_, icon) = sprite_entry;
         icon_to_icons(icon).par_iter().for_each(|icon| {
-            zone!("icon_to_dmi");
-            let icon_path = icon.icon_file.to_owned();
-            {
-                zone!("check_dmi_exists");
-                // scope-in so the lock does not persist during DMI read
-                if icon_file_to_icon().lock().unwrap().contains_key(&icon_path) {
-                    return;
-                }
-            }
-            let reader = BufReader::new(File::open(&icon_path).unwrap());
-            let dmi: Option<Icon>;
-            {
-                zone!("parse_dmi");
-                dmi = Icon::load(reader).ok();
-            }
-            if dmi.is_none() {
-                error.lock().unwrap().push(format!("Invalid DMI: {}", icon_path));
+            if let Err(err) = icon_to_dmi(icon) {
+                error.lock().unwrap().push(err);
                 return;
-            }
-            {
-                zone!("insert_dmi");
-                icon_file_to_icon().lock().unwrap().insert(icon_path, dmi.unwrap().to_owned());
             }
         });
     });
 
-
-
+    // Pick the specific icon states out of the DMI
     sprites_map.par_iter().for_each(|sprite_entry| {
         zone!("map_sprite");
         let (sprite_name, icon) = sprite_entry;
-        let parsed_icon = icon_file_to_icon().lock().unwrap().get(&icon.icon_file).unwrap().to_owned();
-        let mut matched_state: Option<IconState> = Option::None;
-        for icon_state in parsed_icon.states {
-            if icon_state.name == icon.icon_state {
-                matched_state = Option::Some(icon_state.clone());
-                break;
-            }
-        }
-        if matched_state.is_none() {
-            error.lock().unwrap().push(format!("Could not find associated icon state {} for {}", icon.icon_state, sprite_name));
+
+        // get DynamicImage
+        let image_result = icon_to_image(icon, sprite_name);
+        if image_result.is_err() {
+            error.lock().unwrap().push(image_result.unwrap_err());
             return;
         }
-        let state = matched_state.unwrap();
-        if !( if icon.dir == 2 { state.dirs >= 1 } else { state.dirs >= 4 } && state.frames >= icon.frame ) {
-            error.lock().unwrap().push(format!("Could not find associated dir or frame dir: {} frame: {} in {} icon_state - dirs: {} frames: {}", icon.dir, icon.frame, sprite_name, state.dirs, state.frames));
-            return;
-        }
-        let mut icon_idx: u32 = 0;
-        if state.dirs == 4 {
-            icon_idx = match icon.dir {
-                 2 => 0, // South
-                1 => 1, // North
-                4 => 2, // East
-                8 => 3, // West
-                _ => 0,
-            }
-        } else if state.dirs != 1 {
-            error.lock().unwrap().push(format!("Unsupported dirs size of {} in {} state: {} for sprite {}", state.dirs, icon.icon_file, icon.icon_state, sprite_name));
-            return;
-        }
-        if state.frames > 1 {
-            // Add one so zero scales properly
-            icon_idx = (icon_idx + 1) * icon.frame - 1
-        }
-        let image: &DynamicImage = state.images.get(usize::try_from(icon_idx).unwrap()).unwrap();
-        let mut cloned_image: DynamicImage = image.clone();
+        let image = image_result.unwrap();
+
         // apply transforms here
 
         for transform in &icon.transform {
@@ -195,36 +174,38 @@ fn generate_spritesheet(file_path: &str, spritesheet_name: &str, sprites: &str) 
                 Transform::BlendColorTransform { color, blend_mode } => {
                     let mutator = mutate(*blend_mode);
                     let color_parts = decode_hex(color).unwrap();
-                    for x in 0..cloned_image.width() {
-                        for y in 0..cloned_image.height() {
-                            let rgba = cloned_image.get_pixel(x, y).to_rgba();
-                            cloned_image.put_pixel(x, y, blend(rgba, [color_parts[0], color_parts[1], color_parts[2]], mutator))
+                    for x in 0..image.width() {
+                        for y in 0..image.height() {
+                            let rgba = image.get_pixel(x, y).to_rgba();
+                            image.put_pixel(x, y, blend(rgba, [color_parts[0], color_parts[1], color_parts[2]], mutator))
                         }
                     }
                 },
                 Transform::BlendIconTransform { icon, blend_mode } => {
+                    /*
                     let mutator = mutate(*blend_mode);
                     let color_parts = decode_hex(color).unwrap();
-                    for x in 0..cloned_image.width() {
-                        for y in 0..cloned_image.height() {
-                            let rgba = cloned_image.get_pixel(x, y).to_rgba();
-                            cloned_image.put_pixel(x, y, blend(rgba, [color_parts[0], color_parts[1], color_parts[2]], mutator))
+                    for x in 0..image.width() {
+                        for y in 0..image.height() {
+                            let rgba = image.get_pixel(x, y).to_rgba();
+                            image.put_pixel(x, y, blend(rgba, [color_parts[0], color_parts[1], color_parts[2]], mutator))
                         }
                     }
+                    */
                 },
                 Transform::ScaleTransform { width, height } => {
-                    cloned_image.resize_exact(*width, *height, image::imageops::FilterType::Nearest);
+                    *image = image.resize_exact(*width, *height, image::imageops::FilterType::Nearest);
                 }
                 Transform::CropTransform { x1, y1, x2, y2 } => {
-                    //cloned_image = cloned_image.crop_imm(x1, y1, x2 - x1, y2 - y1)
+                    //*image = image.crop_imm(x1, y1, x2 - x1, y2 - y1)
                 }
             }
         }
 
-        let size_id = format!("{}x{}", cloned_image.width(), cloned_image.height());
+        let size_id = format!("{}x{}", image.width(), image.height());
         let mut size_map = size_to_images.lock().unwrap();
         let vec = (*size_map).entry(size_id.to_owned()).or_insert(Vec::new());
-        vec.push(cloned_image);
+        vec.push(image);
         sprites_objects.lock().unwrap().insert(sprite_name.to_owned(), SpritesheetEntry {
             size_id: size_id.to_owned(),
             position: u32::try_from(vec.len()).unwrap() - 1
@@ -257,7 +238,7 @@ fn generate_spritesheet(file_path: &str, spritesheet_name: &str, sprites: &str) 
         }
     });
 
-    let sizes: Vec<String> = size_to_images.lock().unwrap().clone().into_keys().collect();
+    let sizes: Vec<String> = size_to_images.lock().unwrap().iter().map(|(k, _v)| k).cloned().collect();
 
     let returned = Returned {
         sizes: sizes,
@@ -267,19 +248,112 @@ fn generate_spritesheet(file_path: &str, spritesheet_name: &str, sprites: &str) 
     Ok(serde_json::to_string::<Returned>(&returned).unwrap())
 }
 
-fn icon_to_icons(icon: &IconObject) -> Vec<IconObject> {
-    let mut icons: Vec<IconObject> = Vec::new();
-    icons.push(icon.to_owned());
+/// Takes in an icon and gives a list of nested icons. Also returns a reference to the provided icon in the list.
+fn icon_to_icons(icon: &IconObject) -> Vec<&IconObject> {
+    let mut icons: Vec<&IconObject> = Vec::new();
+    icons.push(icon);
     for transform in &icon.transform {
         match transform {
             Transform::BlendIconTransform { icon, .. } => {
-                let nested = icon_to_icons(&icon);
-                icons.extend(nested.to_owned());
+                let nested = icon_to_icons(icon);
+                for icon in nested {
+                    icons.push(icon)
+                }
             }
             _ => {}
         }
     }
     return icons;
+}
+
+/// Given an IconObject, returns a DMI Icon structure and caches it.
+fn icon_to_dmi(icon: &IconObject) -> Result<&Icon, String> {
+    zone!("icon_to_dmi");
+    let icon_path: String = icon.icon_file;
+    {
+        zone!("check_dmi_exists");
+        // scope-in so the lock does not persist during DMI read
+        let found_icon = ICON_FILES.lock().unwrap().get(&icon_path);
+        if found_icon.is_some() {
+            return Ok(found_icon.unwrap());
+        }
+    }
+    let reader = BufReader::new(File::open(&icon_path).unwrap());
+    let dmi: Option<Icon>;
+    {
+        zone!("parse_dmi");
+        dmi = Icon::load(reader).ok();
+    }
+    if dmi.is_none() {
+        return Err(format!("Invalid DMI: {}", icon_path));
+    }
+    {
+        zone!("insert_dmi");
+        let my_dmi = dmi.unwrap();
+        // cache it for later.
+        // Ownership is given to the hashmap
+        ICON_FILES.lock().unwrap().insert(icon_path,my_dmi);
+        return Ok(&my_dmi);
+    }
+}
+
+fn icon_to_image<'a>(icon: &'a IconObject, sprite_name: &String) -> Result<&'a mut DynamicImage, String> {
+    {
+        zone!("check_dynamicimage_exists");
+        // scope-in so the lock does not persist during DMI read
+        let found_icon = ICON_STATES.lock().unwrap().get(&icon.to_icostring());
+        if found_icon.is_some() {
+            return Ok(*found_icon.unwrap())
+        }
+    }
+    let result = icon_to_dmi(icon);
+    if result.is_err()  {
+        return Err(result.unwrap_err());
+    }
+    let dmi = result.unwrap();
+    let mut matched_state: Option<&IconState> = Option::None;
+    {
+        zone!("match_icon_state");
+        for icon_state in dmi.states {
+            if icon_state.name == icon.icon_state {
+                matched_state = Option::Some(&icon_state);
+                break;
+            }
+        }
+    }
+    if matched_state.is_none() {
+        return Err(format!("Could not find associated icon state {} for {}", icon.icon_state, sprite_name));
+    }
+    let state = matched_state.unwrap();
+    {
+        zone!("determine_icon_state_validity");
+        if state.frames < icon.frame {
+            return Err(format!("Could not find associated frame: {} in {} icon_state {} - dirs: {} frames: {}", icon.frame, sprite_name, icon.icon_state, state.dirs, state.frames));
+        }
+        if (state.dirs == 1 && icon.dir != SOUTH)
+        || (state.dirs == 4 && !FOUR_DIRS.contains(&icon.dir))
+        || (state.dirs == 8 && !EIGHT_DIRS.contains(&icon.dir)) {
+            return Err(format!("Invalid dir {} or size of dirs {} in {} state: {} for sprite {}", icon.dir, state.dirs, icon.icon_file, icon.icon_state, sprite_name));
+        }
+
+    }
+    let icon_index = DIR_TO_INDEX.get(icon.dir as usize);
+    if icon_index.is_none() || *icon_index.unwrap() == 255 {
+        return Err(format!("Invalid dir {} or size of dirs {} in {} state: {} for sprite {}", icon.dir, state.dirs, icon.icon_file, icon.icon_state, sprite_name));
+    }
+    let mut icon_idx: u32 = *icon_index.unwrap() as u32;
+    if icon.frame > 1 {
+        // Add one so zero scales properly
+        icon_idx = (icon_idx + 1) * icon.frame - 1
+    }
+    let image: &mut DynamicImage = state.images.get_mut(icon_idx as usize).unwrap();
+    {
+        zone!("insert_dynamicimage");
+        // cache it for later.
+        // Ownership is given to the hashmap
+        ICON_STATES.lock().unwrap().insert(icon.to_icostring(), image);
+    }
+    return Ok(image);
 }
 
 fn mutate(blend_mode: u8) -> fn(u8, u8) -> u8 {

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -640,7 +640,7 @@ fn blend(color: Rgba, color2: Rgba, blend_mode: u8) -> Rgba {
         3 => Rgba::map_each_a(
             color,
             color2,
-            &|c1, c2, _c1_a, c2_a| c1 + (c2 - c1) * c2_a,
+            &|c1, c2, _c1_a, c2_a| c1 + (c2 - c1) * c2_a / 255.0,
             &|a1, a2| {
                 let high = f32::max(a1, a2);
                 let low = f32::min(a1, a2);
@@ -650,7 +650,7 @@ fn blend(color: Rgba, color2: Rgba, blend_mode: u8) -> Rgba {
         6 => Rgba::map_each_a(
             color2,
             color,
-            &|c1, c2, _c1_a, c2_a| c1 + (c2 - c1) * c2_a,
+            &|c1, c2, _c1_a, c2_a| c1 + (c2 - c1) * c2_a / 255.0,
             &|a1, a2| {
                 let high = f32::max(a1, a2);
                 let low = f32::min(a1, a2);

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -575,10 +575,10 @@ struct Rgba {
 impl Rgba {
     fn into_array(self) -> [u8; 4] {
         [
-            strict_f32_to_u8(self.r),
-            strict_f32_to_u8(self.g),
-            strict_f32_to_u8(self.b),
-            strict_f32_to_u8(self.a),
+            self.r.round() as u8,
+            self.g.round() as u8,
+            self.b.round() as u8,
+            self.a.round() as u8,
         ]
     }
 
@@ -659,15 +659,4 @@ fn blend(color: Rgba, color2: Rgba, blend_mode: u8) -> Rgba {
         ),
         _ => color,
     }
-}
-
-/// caps an f32 into u8 ranges, rounds it to the nearest integer, then truncates to a u8.
-fn strict_f32_to_u8(x: f32) -> u8 {
-    if x < u8::MIN as f32 {
-        return 0;
-    }
-    if x > u8::MAX as f32 {
-        return u8::MAX;
-    }
-    x.round().trunc() as u8
 }

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -175,7 +175,7 @@ fn generate_spritesheet(file_path: &str, spritesheet_name: &str, sprites: &str) 
             let size_id = format!("{}x{}", image.width(), image.height());
             return_image(image, icon);
             let mut size_map = size_to_icon_objects.lock().unwrap();
-            let vec = (*size_map).entry(size_id.to_owned()).or_insert(Vec::new());
+            let vec = (*size_map).entry(size_id.to_owned()).or_default();
             vec.push(icon);
 
             sprites_objects.lock().unwrap().insert(sprite_name.to_owned(), SpritesheetEntry {
@@ -363,7 +363,9 @@ fn transform_image(image_in: DynamicImage, icon: &IconObject, sprite_name: &Stri
                     hex = format!("{}ff", hex);
                 }
                 let mut color2: [u8; 4] = [0, 0, 0, 255];
-                hex::decode_to_slice(hex, &mut color2).expect(&format!("Decoding hex color {} failed", color));
+                if let Err(err) = hex::decode_to_slice(hex, &mut color2) {
+                    error.push(format!("Decoding hex color {} failed: {}", color, err.to_string()));
+                }
                 for x in 0..image.width() {
                     for y in 0..image.height() {
                         let px = image.get_pixel(x, y);

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -11,7 +11,7 @@ use dmi::{
 use image::{Pixel, RgbaImage};
 use once_cell::sync::Lazy;
 use rayon::iter::{
-    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+    IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
 };
 use serde::{Deserialize, Serialize};
 use std::{

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -8,9 +8,11 @@ use dmi::{
     dirs::Dirs,
     icon::{Icon, IconState},
 };
-use image::{DynamicImage, GenericImage, GenericImageView, ImageBuffer, Pixel};
+use image::{Pixel, RgbaImage};
 use once_cell::sync::Lazy;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -20,7 +22,7 @@ use std::{
 };
 use tracy_full::{frame, zone};
 static ICON_FILES: Lazy<DashMap<String, Arc<Icon>>> = Lazy::new(DashMap::new);
-static ICON_STATES: Lazy<DashMap<String, DynamicImage>> = Lazy::new(DashMap::new);
+static ICON_STATES: Lazy<DashMap<String, RgbaImage>> = Lazy::new(DashMap::new);
 
 /// This is an array mapping the DIR number from above to a position in DMIs, such that DIR_TO_INDEX[DIR] = dmi::dirs::DIR_ORDERING.indexof(DIR)
 /// 255 is invalid.
@@ -53,10 +55,18 @@ byond_fn!(fn iconforge_check(id) {
     Some(jobs::check(id))
 });
 
+byond_fn!(
+    fn iconforge_cleanup() {
+        ICON_FILES.clear();
+        ICON_STATES.clear();
+        Some("Ok")
+    }
+);
+
 #[derive(Serialize)]
 struct SpritesheetResult {
     sizes: Vec<String>,
-    sprites: HashMap<String, SpritesheetEntry>,
+    sprites: DashMap<String, SpritesheetEntry>,
     error: String,
 }
 
@@ -66,25 +76,73 @@ struct SpritesheetEntry {
     position: u32,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Clone, Eq, PartialEq, Hash)]
 struct IconObject {
     icon_file: String,
     icon_state: String,
     dir: u8,
     frame: u32,
-    moving: u8,
     transform: Vec<Transform>,
+    icostring: String,
 }
 
-impl IconObject {
-    fn to_icostring(&self) -> Result<String, Error> {
-        zone!("to_icostring");
-        string_hash("xxh64", &serde_json::to_string(self)?)
+#[derive(Serialize, Deserialize)]
+struct IconObjectIO {
+    icon_file: String,
+    icon_state: String,
+    dir: u8,
+    frame: u32,
+    transform: Vec<TransformIO>,
+}
+
+impl std::fmt::Display for IconObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "IconObject(icon_file={}, icon_state={}, dir={}, frame={})",
+            self.icon_file, self.icon_state, self.dir, self.frame
+        )
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+impl IconObject {
+    fn to_base(&self) -> Result<String, Error> {
+        zone!("to_base");
+        string_hash(
+            "xxh64",
+            &format!(
+                "{}.{}.{}.{}",
+                self.icon_file, self.icon_state, self.dir, self.frame
+            ),
+        )
+    }
+
+    fn gen_icostring_input(&self, transform: &[Transform]) -> Result<String, Error> {
+        zone!("gen_icostring_input");
+        Ok(format!(
+            "{}-{}",
+            self.to_base()?,
+            serde_json::to_string(transform)?
+        ))
+    }
+
+    fn gen_icostring(&mut self) -> Result<(), Error> {
+        zone!("gen_icostring");
+        self.icostring = string_hash("xxh64", &self.gen_icostring_input(&self.transform)?)?;
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
 #[serde(tag = "type")]
+enum TransformIO {
+    BlendColor { color: String, blend_mode: u8 },
+    BlendIcon { icon: IconObjectIO, blend_mode: u8 },
+    Scale { width: u32, height: u32 },
+    Crop { x1: i32, y1: i32, x2: i32, y2: i32 },
+}
+
+#[derive(Serialize, Clone, Eq, PartialEq, Hash)]
 enum Transform {
     BlendColor { color: String, blend_mode: u8 },
     BlendIcon { icon: IconObject, blend_mode: u8 },
@@ -127,28 +185,121 @@ fn generate_spritesheet(
     let error = Arc::new(Mutex::new(Vec::<String>::new()));
 
     let size_to_icon_objects = Arc::new(Mutex::new(HashMap::<String, Vec<&IconObject>>::new()));
-    let sprites_map = serde_json::from_str::<HashMap<String, IconObject>>(sprites)?;
-    let sprites_objects = Arc::new(Mutex::new(HashMap::<String, SpritesheetEntry>::new()));
+    let sprites_objects = DashMap::<String, SpritesheetEntry>::new();
+
+    let tree_bases = Arc::new(Mutex::new(
+        HashMap::<String, Vec<(&String, &IconObject)>>::new(),
+    ));
+    let input;
+    {
+        zone!("from_json");
+        input = serde_json::from_str::<HashMap<String, IconObjectIO>>(sprites)?;
+    }
+    let mut sprites_map = HashMap::<String, IconObject>::new();
+    {
+        zone!("io_to_mem");
+        sprites_map.extend(
+            input
+                .into_par_iter()
+                .map(|(sprite_name, icon)| (sprite_name, icon_from_io(icon)))
+                .collect::<Vec<(String, IconObject)>>(),
+        );
+    }
 
     // Pre-load all the DMIs now.
     // This is much faster than doing it as we go (tested!), because sometimes multiple parallel iterators need the DMI.
-    sprites_map.par_iter().for_each(|sprite_entry| {
+    sprites_map.par_iter().for_each(|(sprite_name, icon)| {
         zone!("sprite_to_icons");
-        let (_, icon) = sprite_entry;
-        icon_to_icons(icon).par_iter().for_each(|icon| {
+
+        icon_to_icons(icon).into_par_iter().for_each(|icon| {
             if let Err(err) = icon_to_dmi(icon) {
                 error.lock().unwrap().push(err);
             }
         });
+
+        {
+            zone!("map_to_base");
+            let base = match icon.to_base() {
+                Ok(base) => base,
+                Err(err) => {
+                    error.lock().unwrap().push(err.to_string());
+                    return;
+                }
+            };
+            tree_bases
+                .lock()
+                .unwrap()
+                .entry(base)
+                .or_default()
+                .push((sprite_name, icon));
+        }
     });
+
+    // cache this here so we don't generate the same string 5000 times
+    let sprite_name = "N/A, in tree generation stage".to_string();
+
+    // Map duplicate transform sets into a tree.
+    // This is beneficial in the case where we have the same base image, and the same set of transforms, but change 1 or 2 things at the end.
+    // We can greatly reduce the amount of RgbaImages created by first finding these.
+    tree_bases
+        .lock()
+        .unwrap()
+        .par_iter()
+        .for_each(|(_, icons)| {
+            zone!("transform_trees");
+            let first_icon = match icons.first() {
+                Some((_, icon)) => icon,
+                None => {
+                    error
+                        .lock()
+                        .unwrap()
+                        .push("Somehow found no icon for a tree.".to_string());
+                    return;
+                }
+            };
+            let (base_image, _) = match icon_to_image(first_icon, &sprite_name, false, false) {
+                Ok(image) => image,
+                Err(err) => {
+                    error.lock().unwrap().push(err);
+                    return;
+                }
+            };
+            let unique_icons = DashMap::<Vec<Transform>, &IconObject>::new();
+            {
+                zone!("map_unique");
+                icons.iter().for_each(|(_, icon)| {
+                    // This will ensure we only map unique transform sets. This also means each IconObject is guaranteed a unique IcoString
+                    // Since all icons share the same 'base'.
+                    // Also check to see if the icon is already cached. If so, we can ignore this transform chain.
+                    if !ICON_STATES.contains_key(&icon.icostring) {
+                        unique_icons.insert(icon.transform.clone(), icon);
+                    }
+                });
+            }
+            if let Some(entry) = unique_icons.get(&Vec::new()) {
+                if let Err(err) = return_image(base_image.clone(), entry.value()) {
+                    error.lock().unwrap().push(err.to_string());
+                }
+            }
+            {
+                zone!("transform_all_leaves");
+                if let Err(err) = transform_leaves(
+                    &unique_icons.into_iter().map(|(_, v)| v).collect(),
+                    base_image,
+                    0,
+                ) {
+                    error.lock().unwrap().push(err);
+                }
+            }
+        });
 
     // Pick the specific icon states out of the DMI, also generating their transforms, build the spritesheet metadata.
     sprites_map.par_iter().for_each(|sprite_entry| {
         zone!("map_sprite");
         let (sprite_name, icon) = sprite_entry;
 
-        // get DynamicImage, applying transforms as well
-        let image = match icon_to_image(icon, sprite_name) {
+        // get RgbaImage, it should already be transformed, so it must be cached.
+        let (image, _) = match icon_to_image(icon, sprite_name, true, true) {
             Ok(image) => image,
             Err(err) => {
                 error.lock().unwrap().push(err);
@@ -175,7 +326,7 @@ fn generate_spritesheet(
 
             {
                 zone!("insert_into_sprite_objects");
-                sprites_objects.lock().unwrap().insert(
+                sprites_objects.insert(
                     sprite_name.to_owned(),
                     SpritesheetEntry {
                         size_id: size_id.to_owned(),
@@ -214,12 +365,12 @@ fn generate_spritesheet(
                 .unwrap();
 
             let mut final_image =
-                DynamicImage::new_rgba8(base_width * icon_objects.len() as u32, base_height);
+                RgbaImage::new(base_width * icon_objects.len() as u32, base_height);
 
             for (idx, icon) in icon_objects.iter().enumerate() {
                 zone!("join_sprite");
-                let image = match icon_to_image(icon, &sprite_name) {
-                    Ok(image) => image,
+                let image = match icon_to_image(icon, &sprite_name, true, true) {
+                    Ok((image, _)) => image,
                     Err(err) => {
                         error.lock().unwrap().push(err);
                         return;
@@ -228,8 +379,11 @@ fn generate_spritesheet(
                 let base_x: u32 = base_width * idx as u32;
                 for x in 0..image.width() {
                     for y in 0..image.height() {
-                        final_image.put_pixel(base_x + x, y, image.get_pixel(x, y))
+                        final_image.put_pixel(base_x + x, y, *image.get_pixel(x, y))
                     }
+                }
+                if let Err(err) = return_image(image, icon) {
+                    error.lock().unwrap().push(err.to_string());
                 }
             }
             {
@@ -249,18 +403,114 @@ fn generate_spritesheet(
     // Collect the game metadata and any errors.
     let returned = SpritesheetResult {
         sizes,
-        sprites: sprites_objects.lock().unwrap().to_owned(),
+        sprites: sprites_objects,
         error: error.lock().unwrap().join("\n"),
     };
     Ok(serde_json::to_string::<SpritesheetResult>(&returned)?)
 }
 
+/// Given an array of 'transform arrays' onto from a shared IconObject base,
+/// recursively applies transforms in a tree structure. Maximum transform depth is 128.
+fn transform_leaves(icons: &Vec<&IconObject>, image: RgbaImage, depth: u8) -> Result<(), String> {
+    zone!("transform_leaf");
+    if depth > 128 {
+        return Err(
+            "Transform depth exceeded 128. https://www.youtube.com/watch?v=CUjrySBwi5Q".to_string(),
+        );
+    }
+    let next_transforms = DashMap::<Transform, Vec<&IconObject>>::new();
+    let errors = Mutex::new(Vec::<String>::new());
+
+    {
+        zone!("get_next_transforms");
+        icons.par_iter().for_each(|icon| {
+            zone!("collect_icon_transforms");
+            if let Some(transform) = icon.transform.get(depth as usize) {
+                next_transforms
+                    .entry(transform.clone())
+                    .or_default()
+                    .push(icon);
+            }
+        });
+    }
+
+    {
+        zone!("do_next_transforms");
+        next_transforms
+            .into_par_iter()
+            .for_each(|(transform, mut associated_icons)| {
+                let mut altered_image;
+                {
+                    zone!("clone_image");
+                    altered_image = image.clone();
+                }
+                if let Err(err) = transform_image(&mut altered_image, &transform) {
+                    errors.lock().unwrap().push(err);
+                }
+                {
+                    zone!("filter_associated_icons");
+                    associated_icons
+                        .clone()
+                        .into_iter()
+                        .enumerate()
+                        .for_each(|(idx, icon)| {
+                            if icon.transform.len() as u8 == depth + 1
+                                && *icon.transform.last().unwrap() == transform
+                            {
+                                associated_icons.swap_remove(idx);
+                                if let Err(err) = return_image(altered_image.clone(), icon) {
+                                    errors.lock().unwrap().push(err.to_string());
+                                }
+                            }
+                        });
+                }
+                if let Err(err) = transform_leaves(&associated_icons, altered_image, depth + 1) {
+                    errors.lock().unwrap().push(err);
+                }
+            });
+    }
+
+    if !errors.lock().unwrap().is_empty() {
+        return Err(errors.lock().unwrap().join("\n"));
+    }
+    Ok(())
+}
+
+/// Converts an IO icon to one with icostrings
+fn icon_from_io(icon_in: IconObjectIO) -> IconObject {
+    zone!("icon_from_io");
+    let mut result = IconObject {
+        icon_file: icon_in.icon_file,
+        icon_state: icon_in.icon_state,
+        dir: icon_in.dir,
+        frame: icon_in.frame,
+        transform: icon_in
+            .transform
+            .into_iter()
+            .map(|transform_in| match transform_in {
+                TransformIO::BlendColor { color, blend_mode } => {
+                    Transform::BlendColor { color, blend_mode }
+                }
+                TransformIO::BlendIcon { icon, blend_mode } => Transform::BlendIcon {
+                    icon: icon_from_io(icon),
+                    blend_mode,
+                },
+                TransformIO::Crop { x1, y1, x2, y2 } => Transform::Crop { x1, y1, x2, y2 },
+                TransformIO::Scale { width, height } => Transform::Scale { width, height },
+            })
+            .collect(),
+        icostring: String::new(),
+    };
+    result.gen_icostring().unwrap(); // unsafe but idc
+    result
+}
+
 /// Takes in an icon and gives a list of nested icons. Also returns a reference to the provided icon in the list.
-fn icon_to_icons(icon: &IconObject) -> Vec<&IconObject> {
+fn icon_to_icons(icon_in: &IconObject) -> Vec<&IconObject> {
     zone!("icon_to_icons");
     let mut icons: Vec<&IconObject> = Vec::new();
-    icons.push(icon);
-    for transform in &icon.transform {
+    icons.push(icon_in);
+    for transform in &icon_in.transform {
         if let Transform::BlendIcon { icon, .. } = transform {
             let nested = icon_to_icons(icon);
             for icon in nested {
@@ -283,8 +533,8 @@ fn icon_to_dmi(icon: &IconObject) -> Result<Arc<Icon>, String> {
     }
     let icon_file = match File::open(icon_path) {
         Ok(icon_file) => icon_file,
-        Err(_) => {
-            return Err(format!("No such DMI file: {}", icon_path));
+        Err(err) => {
+            return Err(format!("Failed to open DMI '{}' - {}", icon_path, err));
         }
     };
     let reader = BufReader::new(icon_file);
@@ -293,8 +543,8 @@ fn icon_to_dmi(icon: &IconObject) -> Result<Arc<Icon>, String> {
         zone!("parse_dmi");
         dmi = match Icon::load(reader) {
             Ok(dmi) => dmi,
-            Err(_) => {
-                return Err(format!("Invalid DMI: {}", icon_path));
+            Err(err) => {
+                return Err(format!("DMI '{}' failed to parse - {}", icon_path, err));
             }
         };
     }
@@ -308,20 +558,29 @@ fn icon_to_dmi(icon: &IconObject) -> Result<Arc<Icon>, String> {
     }
 }
 
-/// Takes an IconObject, gets its DMI, then picks out a DynamicImage for the IconState, as well as transforms the DynamicImage.
+/// Takes an IconObject, gets its DMI, then picks out a RgbaImage for the IconState.
+/// Returns with True if the RgbaImage is pre-cached (and shouldn't have new transforms applied)
 /// Gives ownership over the image. Please return when you are done <3 (via return_image)
-fn icon_to_image(icon: &IconObject, sprite_name: &String) -> Result<DynamicImage, String> {
+fn icon_to_image(
+    icon: &IconObject,
+    sprite_name: &String,
+    cached: bool,
+    must_be_cached: bool,
+) -> Result<(RgbaImage, bool), String> {
     zone!("icon_to_image");
-    {
-        zone!("check_dynamicimage_exists");
-        let ico_string = match icon.to_icostring() {
-            Ok(ico_string) => ico_string,
-            Err(err) => {
-                return Err(err.to_string());
-            }
-        };
-        if let Some((_key, value)) = ICON_STATES.remove(&ico_string) {
-            return Ok(value);
+    if cached {
+        zone!("check_rgba_image_exists");
+        if icon.icostring.is_empty() {
+            return Err(format!(
+                "No icostring generated for {} {}",
+                icon, sprite_name
+            ));
+        }
+        if let Some(entry) = ICON_STATES.get(&icon.icostring) {
+            return Ok((entry.value().clone(), true));
+        }
+        if must_be_cached {
+            return Err("Image not found in cache!".to_string());
         }
     }
     let dmi = icon_to_dmi(icon)?;
@@ -362,7 +621,7 @@ fn icon_to_image(icon: &IconObject, sprite_name: &String) -> Result<DynamicImage
             }
         };
         if (state.dirs == 1 && dir != Dirs::SOUTH)
-            || (state.dirs == 4 && !dmi::dirs::ORDINAL_DIRS.contains(&dir))
+            || (state.dirs == 4 && !dmi::dirs::CARDINAL_DIRS.contains(&dir))
             || (state.dirs == 8 && !dmi::dirs::ALL_DIRS.contains(&dir))
         {
             return Err(format!(
@@ -390,176 +649,172 @@ fn icon_to_image(icon: &IconObject, sprite_name: &String) -> Result<DynamicImage
         // Add one so zero scales properly
         icon_idx = (icon_idx + 1) * icon.frame - 1
     }
-    let image = match state.images.get(icon_idx as usize) {
-        Some(image) => image.clone(),
+    Ok(match state.images.get(icon_idx as usize) {
+        Some(image) => (image.to_rgba8(), false),
         None => {
             return Err(
                 format!("Out of bounds index {} in icon_state {} for sprite {} - Maximum index: {} (frames: {}, dirs: {})",
                 icon_idx, icon.icon_state, sprite_name, state.images.len(), state.dirs, state.frames
             ));
         }
-    };
-    // Apply transforms
-    let (transformed_image, errors) = transform_image(image, icon, sprite_name);
-    if !errors.is_empty() {
-        return Err(errors);
-    }
-    Ok(transformed_image)
+    })
 }
 
 /// Gives an image back to the cache, after it is done being used.
-fn return_image(image: DynamicImage, icon: &IconObject) -> Result<(), Error> {
-    zone!("insert_dynamicimage");
-    ICON_STATES.insert(icon.to_icostring()?, image);
+fn return_image(image: RgbaImage, icon: &IconObject) -> Result<(), Error> {
+    zone!("insert_rgbaimage");
+    if icon.icostring.is_empty() {
+        return Err(Error::IconForge(format!(
+            "No icostring generated for {}",
+            icon
+        )));
+    }
+    ICON_STATES.insert(icon.icostring.to_owned(), image);
     Ok(())
 }
 
-/// Applies transforms to a DynamicImage.
-fn transform_image(
-    image_in: DynamicImage,
-    icon: &IconObject,
-    sprite_name: &String,
-) -> (DynamicImage, String) {
+fn apply_all_transforms(image: &mut RgbaImage, transforms: &Vec<Transform>) -> Result<(), String> {
+    let mut errors = Vec::<String>::new();
+    for transform in transforms {
+        if let Err(error) = transform_image(image, transform) {
+            errors.push(error);
+        }
+    }
+    if !errors.is_empty() {
+        return Err(errors.join("\n"));
+    }
+    Ok(())
+}
+
+/// Applies transforms to a RgbaImage.
+fn transform_image(image: &mut RgbaImage, transform: &Transform) -> Result<(), String> {
     zone!("transform_image");
-    let mut image = image_in;
-    let mut error: Vec<String> = Vec::new();
-    for transform in &icon.transform {
-        match transform {
-            Transform::BlendColor { color, blend_mode } => {
-                zone!("blend_color");
+    match transform {
+        Transform::BlendColor { color, blend_mode } => {
+            zone!("blend_color");
+            let mut color2: [u8; 4] = [0, 0, 0, 255];
+            {
+                zone!("from_hex");
                 let mut hex: String = color.to_owned();
                 if hex.starts_with('#') {
                     hex = hex[1..].to_string();
                 }
                 if hex.len() == 6 {
-                    hex = format!("{}ff", hex);
+                    hex += "ff";
                 }
-                let mut color2: [u8; 4] = [0, 0, 0, 255];
+
                 if let Err(err) = hex::decode_to_slice(hex, &mut color2) {
-                    error.push(format!("Decoding hex color {} failed: {}", color, err));
-                }
-                for x in 0..image.width() {
-                    for y in 0..image.height() {
-                        let px = image.get_pixel(x, y);
-                        let pixel = px.channels();
-                        let blended = blend_u8(pixel, &color2, *blend_mode);
-
-                        image.put_pixel(x, y, image::Rgba::<u8>(blended));
-                    }
+                    return Err(format!("Decoding hex color {} failed: {}", color, err));
                 }
             }
-            Transform::BlendIcon { icon, blend_mode } => {
-                zone!("blend_icon");
-                let other_image = match icon_to_image(
-                    icon,
-                    &format!("Transform blend_icon of {}", sprite_name),
-                ) {
-                    Ok(other_image) => other_image,
-                    Err(err) => {
-                        error.push(err);
-                        continue;
-                    }
-                };
+            for x in 0..image.width() {
+                for y in 0..image.height() {
+                    let px = image.get_pixel_mut(x, y);
+                    let pixel = px.channels();
+                    let blended = blend_u8(pixel, &color2, *blend_mode);
 
-                for x in 0..image.width() {
-                    if x >= other_image.width() {
-                        break; // undefined behavior in DM :)
-                    }
-                    for y in 0..image.height() {
-                        if y >= other_image.height() {
-                            break; // undefined behavior in DM :)
-                        }
-                        let px1 = image.get_pixel(x, y);
-                        let px2 = other_image.get_pixel(x, y);
-                        let pixel_1 = px1.channels();
-                        let pixel_2 = px2.channels();
-
-                        let blended = blend_u8(pixel_1, pixel_2, *blend_mode);
-
-                        image.put_pixel(x, y, image::Rgba::<u8>(blended));
-                    }
+                    *px = image::Rgba::<u8>(blended);
                 }
-                if let Err(err) = return_image(other_image, icon) {
-                    error.push(err.to_string());
-                }
-            }
-            Transform::Scale { width, height } => {
-                zone!("scale");
-                let x_ratio = image.width() as f32 / *width as f32;
-                let y_ratio = image.height() as f32 / *height as f32;
-                let mut new_image = DynamicImage::new_rgba8(*width, *height);
-                for x in 0..*width {
-                    for y in 0..*height {
-                        let old_x: u32 = (x as f32 * x_ratio).floor() as u32;
-                        let old_y: u32 = (y as f32 * y_ratio).floor() as u32;
-                        let pixel = image.get_pixel(old_x, old_y);
-                        new_image.put_pixel(x, y, pixel);
-                    }
-                }
-                image = new_image;
-            }
-            Transform::Crop { x1, y1, x2, y2 } => {
-                zone!("crop");
-                let i_width = image.width();
-                let i_height = image.height();
-                let mut x1 = *x1;
-                let mut y1 = *y1;
-                let mut x2 = *x2;
-                let mut y2 = *y2;
-                if x2 <= x1 || y2 <= y1 {
-                    error.push(format!(
-                        "Invalid bounds {} {} to {} {} from sprite {}",
-                        x1, y1, x2, y2, sprite_name
-                    ));
-                    continue;
-                }
-
-                // convert from BYOND (0,0 is bottom left) to Rust (0,0 is top left)
-                let y2_old = y2;
-                y2 = i_height as i32 - y1;
-                y1 = i_height as i32 - y2_old;
-
-                let mut width = x2 - x1;
-                let mut height = y2 - y1;
-
-                if x1 < 0 || x2 > i_width as i32 || y1 < 0 || y2 > i_height as i32 {
-                    let mut blank_img =
-                        ImageBuffer::from_fn(width as u32, height as u32, |_x, _y| {
-                            image::Rgba([0, 0, 0, 0])
-                        });
-                    image::imageops::overlay(
-                        &mut blank_img,
-                        &image,
-                        if x1 < 0 { (x1).abs() as i64 } else { 0 }
-                            - if x1 > i_width as i32 {
-                                (x1 - i_width as i32) as i64
-                            } else {
-                                0
-                            },
-                        if y1 < 0 { (y1).abs() as i64 } else { 0 }
-                            - if x1 > i_width as i32 {
-                                (x1 - i_width as i32) as i64
-                            } else {
-                                0
-                            },
-                    );
-                    image = DynamicImage::new_rgba8(width as u32, height as u32);
-                    if let Err(err) = image.copy_from(&blank_img, 0, 0) {
-                        error.push(err.to_string());
-                        continue;
-                    }
-                    x1 = std::cmp::max(0, x1);
-                    x2 = std::cmp::min(i_width as i32, x2);
-                    y1 = std::cmp::max(0, y1);
-                    y2 = std::cmp::min(i_height as i32, y2);
-                    width = x2 - x1;
-                    height = y2 - y1;
-                }
-                image = image.crop_imm(x1 as u32, y1 as u32, width as u32, height as u32);
             }
         }
+        Transform::BlendIcon { icon, blend_mode } => {
+            zone!("blend_icon");
+            let (mut other_image, cached) =
+                icon_to_image(icon, &format!("Transform blend_icon {}", icon), true, false)?;
+
+            if !cached {
+                apply_all_transforms(&mut other_image, &icon.transform)?;
+            };
+            for x in 0..std::cmp::min(image.width(), other_image.width()) {
+                for y in 0..std::cmp::min(image.width(), other_image.width()) {
+                    let px1 = image.get_pixel_mut(x, y);
+                    let px2 = other_image.get_pixel(x, y);
+                    let pixel_1 = px1.channels();
+                    let pixel_2 = px2.channels();
+
+                    let blended = blend_u8(pixel_1, pixel_2, *blend_mode);
+
+                    *px1 = image::Rgba::<u8>(blended);
+                }
+            }
+            if let Err(err) = return_image(other_image, icon) {
+                return Err(err.to_string());
+            }
+        }
+        Transform::Scale { width, height } => {
+            zone!("scale");
+            let old_width = image.width() as usize;
+            let old_height = image.height() as usize;
+            let x_ratio = old_width as f32 / *width as f32;
+            let y_ratio = old_height as f32 / *height as f32;
+            let mut new_image = RgbaImage::new(*width, *height);
+            for x in 0..(*width) {
+                for y in 0..(*height) {
+                    let old_x = (x as f32 * x_ratio).floor() as u32;
+                    let old_y = (y as f32 * y_ratio).floor() as u32;
+                    new_image.put_pixel(x, y, *image.get_pixel(old_x, old_y));
+                }
+            }
+            *image = new_image;
+        }
+        Transform::Crop { x1, y1, x2, y2 } => {
+            zone!("crop");
+            let i_width = image.width();
+            let i_height = image.height();
+            let mut x1 = *x1;
+            let mut y1 = *y1;
+            let mut x2 = *x2;
+            let mut y2 = *y2;
+            if x2 <= x1 || y2 <= y1 {
+                return Err(format!(
+                    "Invalid bounds {} {} to {} {} in crop transform",
+                    x1, y1, x2, y2
+                ));
+            }
+
+            // convert from BYOND (0,0 is bottom left) to Rust (0,0 is top left)
+            let y2_old = y2;
+            y2 = i_height as i32 - y1;
+            y1 = i_height as i32 - y2_old;
+
+            let mut width = x2 - x1;
+            let mut height = y2 - y1;
+
+            if x1 < 0 || x2 > i_width as i32 || y1 < 0 || y2 > i_height as i32 {
+                let mut blank_img: image::ImageBuffer<image::Rgba<u8>, Vec<u8>> =
+                    RgbaImage::from_fn(width as u32, height as u32, |_x, _y| {
+                        image::Rgba([0, 0, 0, 0])
+                    });
+                image::imageops::overlay(
+                    &mut blank_img,
+                    image,
+                    if x1 < 0 { (x1).abs() as i64 } else { 0 }
+                        - if x1 > i_width as i32 {
+                            (x1 - i_width as i32) as i64
+                        } else {
+                            0
+                        },
+                    if y1 < 0 { (y1).abs() as i64 } else { 0 }
+                        - if x1 > i_width as i32 {
+                            (x1 - i_width as i32) as i64
+                        } else {
+                            0
+                        },
+                );
+                *image = blank_img;
+                x1 = std::cmp::max(0, x1);
+                x2 = std::cmp::min(i_width as i32, x2);
+                y1 = std::cmp::max(0, y1);
+                y2 = std::cmp::min(i_height as i32, y2);
+                width = x2 - x1;
+                height = y2 - y1;
+            }
+            *image =
+                image::imageops::crop_imm(image, x1 as u32, y1 as u32, width as u32, height as u32)
+                    .to_image();
+        }
     }
-    (image, error.join("\n"))
+    Ok(())
 }
 
 struct Rgba {

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -671,7 +671,9 @@ fn icon_from_io(icon_in: IconObjectIO) -> IconObject {
         transform_hash_input: String::new(),
         icon_hash_input: String::new(),
     };
-    result.gen_icon_hash_input().unwrap(); // unsafe but idc
+    // This line can panic, but I consider that acceptable considering how annoying "proper" error handling would be
+    // especially when this failing basically breaks the entire program. The panic will be caught and written to logs anyway.
+    result.gen_icon_hash_input().unwrap();
     result
 }
 

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -1,0 +1,223 @@
+// DMI spritesheet generator
+// Developed by itsmeow
+use crate::jobs;
+use crate::error::Error;
+use std::{
+    fs::File,
+    io::BufReader,
+};
+use dmi::icon::{Icon, IconState};
+use image::{DynamicImage, GenericImage, GenericImageView};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+//use raster::Image;
+use serde::{Serialize, Deserialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tracy_full::{zone, frame};
+use once_cell::sync::OnceCell;
+
+fn icon_file_to_icon() -> &'static Mutex<HashMap<String, Icon>> {
+    static INSTANCE: OnceCell<Mutex<HashMap<String, Icon>>> = OnceCell::new();
+    INSTANCE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+byond_fn!(fn iconforge_generate(file_path, spritesheet_name, sprites) {
+    catch_panic(file_path, spritesheet_name, sprites).err()
+});
+
+
+byond_fn!(fn iconforge_generate_async(file_path, spritesheet_name, sprites) {
+    let file_path = file_path.to_owned();
+    let spritesheet_name = spritesheet_name.to_owned();
+    let sprites = sprites.to_owned();
+    Some(jobs::start(move || {
+        match catch_panic(&file_path, &spritesheet_name, &sprites) {
+            Ok(o) => o.to_string(),
+            Err(e) => e.to_string()
+        }
+    }))
+});
+
+byond_fn!(fn iconforge_check(id) {
+    Some(jobs::check(id))
+});
+
+#[derive(Serialize)]
+struct Returned {
+    sizes: Vec<String>,
+    sprites: HashMap<String, SpritesheetEntry>,
+    error: String,
+}
+
+#[derive(Serialize, Clone)]
+struct SpritesheetEntry {
+    size_id: String,
+    position: u32,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct IconObject {
+	icon_file: String,
+	icon_state: String,
+	dir: u8,
+	frame: u32,
+	moving: u8,
+	transform: Vec<Transform>
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(tag = "type")]
+enum Transform {
+    BlendColorTransform {
+        color: String,
+        blend_mode: u8,
+    },
+    BlendIconTransform {
+        icon: IconObject,
+        blend_mode: u8,
+    },
+    ScaleTransform {
+        width: u32,
+        height: u32,
+    },
+    CropTransform {
+        x1: u32,
+        y1: u32,
+        x2: u32,
+        y2: u32,
+    }
+}
+
+fn catch_panic(file_path: &str, spritesheet_name: &str, sprites: &str) -> std::result::Result<String, Error> {
+    let x = std::panic::catch_unwind(|| {
+        let result = generate_spritesheet(file_path, spritesheet_name, sprites);
+        frame!();
+        return result;
+    });
+    if x.is_err() {
+        match x.unwrap_err().downcast_ref::<String>() {
+            Some(as_string) => {
+                return Err(Error::IconState(as_string.to_owned()))
+            }
+            None => {
+                return Err(Error::IconState("Failed to stringify panic".to_string()))
+            }
+        }
+    }
+    return x.ok().unwrap()
+}
+
+fn generate_spritesheet(file_path: &str, spritesheet_name: &str, sprites: &str) -> std::result::Result<String, Error> {
+    zone!("generate_spritesheet");
+
+    let error: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let size_to_images: Arc<Mutex<HashMap<String, Vec<DynamicImage>>>> = Arc::new(Mutex::new(HashMap::new()));
+    let sprites_map: HashMap<String, IconObject> = serde_json::from_str::<HashMap<String, IconObject>>(sprites)?;
+    let sprites_objects: Arc<Mutex<HashMap<String, SpritesheetEntry>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    sprites_map.par_iter().for_each(|sprite_entry| {
+        zone!("sprite_to_icon");
+        let (_, icon) = sprite_entry;
+        let icon_path = icon.icon_file.to_owned();
+        if icon_file_to_icon().lock().unwrap().contains_key(&icon_path) {
+            return;
+        }
+        let reader = BufReader::new(File::open(&icon_path).unwrap());
+        let icon: Option<Icon>;
+        {
+            zone!("load_icon");
+            icon = Icon::load(reader).ok();
+        }
+        if icon.is_none() {
+            error.lock().unwrap().push(format!("Invalid DMI: {}", icon_path));
+            return;
+        }
+        icon_file_to_icon().lock().unwrap().insert(icon_path, icon.unwrap().to_owned());
+    });
+
+    sprites_map.par_iter().for_each(|sprite_entry| {
+        zone!("map_sprite");
+        let (sprite_name, icon) = sprite_entry;
+        let parsed_icon = icon_file_to_icon().lock().unwrap().get(&icon.icon_file).unwrap().to_owned();
+        let mut matched_state: Option<IconState> = Option::None;
+        for icon_state in parsed_icon.states {
+            if icon_state.name == icon.icon_state {
+                matched_state = Option::Some(icon_state.clone());
+                break;
+            }
+        }
+        if matched_state.is_none() {
+            error.lock().unwrap().push(format!("Could not find associated icon state {} for {}", icon.icon_state, sprite_name));
+            return;
+        }
+        let state = matched_state.unwrap();
+        if !( if icon.dir == 2 { state.dirs >= 1 } else { state.dirs >= 4 } && state.frames >= icon.frame ) {
+            error.lock().unwrap().push(format!("Could not find associated dir or frame dir: {} frame: {} in {} icon_state - dirs: {} frames: {}", icon.dir, icon.frame, sprite_name, state.dirs, state.frames));
+            return;
+        }
+        let mut icon_idx: u32 = 0;
+        if state.dirs == 4 {
+            icon_idx = match icon.dir {
+                 2 => 0, // South
+                1 => 1, // North
+                4 => 2, // East
+                8 => 3, // West
+                _ => 0,
+            }
+        } else if state.dirs != 1 {
+            error.lock().unwrap().push(format!("Unsupported dirs size of {} in {} state: {} for sprite {}", state.dirs, icon.icon_file, icon.icon_state, sprite_name));
+            return;
+        }
+        if state.frames > 1 {
+            // Add one so zero scales properly
+            icon_idx = (icon_idx + 1) * icon.frame - 1
+        }
+        let image: &DynamicImage = state.images.get(usize::try_from(icon_idx).unwrap()).unwrap();
+        let cloned_image: DynamicImage = image.clone();
+        // apply transforms here
+        let size_id = format!("{}x{}", cloned_image.width(), cloned_image.height());
+        let mut size_map = size_to_images.lock().unwrap();
+        let vec = (*size_map).entry(size_id.to_owned()).or_insert(Vec::new());
+        vec.push(cloned_image);
+        sprites_objects.lock().unwrap().insert(sprite_name.to_owned(), SpritesheetEntry {
+            size_id: size_id.to_owned(),
+            position: u32::try_from(vec.len()).unwrap() - 1
+        });
+    });
+
+    size_to_images.lock().unwrap().par_iter().for_each(|(size_id, images_list)| {
+        zone!("join_sprites");
+        let file_path = format!("{}{}_{}.png", file_path, spritesheet_name, size_id);
+        let size_data: Vec<&str> = size_id.split("x").collect();
+        let base_width = size_data.first().unwrap().to_string().parse::<u32>().unwrap();
+        let base_height = size_data.last().unwrap().to_string().parse::<u32>().unwrap();
+
+        let image_count: u32 = u32::try_from(images_list.len()).unwrap();
+        let mut final_image = DynamicImage::new_rgba8(base_width * image_count, base_height);
+
+        for idx in 0..image_count {
+            zone!("join_sprite");
+            let image: &DynamicImage = images_list.get::<usize>(usize::try_from(idx).unwrap()).unwrap();
+            let base_x: u32 = base_width * idx;
+            for x in 0..image.width() {
+                for y in 0..image.height() {
+                    final_image.put_pixel(base_x + x, y, image.get_pixel(x, y))
+                }
+            }
+        }
+        {
+            zone!("write_spritesheet");
+            final_image.save(file_path).err();
+        }
+    });
+
+    let sizes: Vec<String> = size_to_images.lock().unwrap().clone().into_keys().collect();
+
+    let returned = Returned {
+        sizes: sizes,
+        sprites: sprites_objects.lock().unwrap().to_owned(),
+        error: error.lock().unwrap().join("\n"),
+    };
+    Ok(serde_json::to_string::<Returned>(&returned).unwrap())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_op_in_unsafe_fn)]
+#![feature(local_key_cell_methods)]
 
 #[macro_use]
 mod byond;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,3 +50,6 @@ pub mod unzip;
 pub mod url;
 #[cfg(feature = "worleynoise")]
 pub mod worleynoise;
+
+#[cfg(not(target_pointer_width = "32"))]
+compile_error!("rust-g must be compiled for a 32-bit target");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod git;
 pub mod hash;
 #[cfg(feature = "http")]
 pub mod http;
+#[cfg(feature = "iconforge")]
+pub mod iconforge;
 #[cfg(feature = "json")]
 pub mod json;
 #[cfg(feature = "log")]
@@ -48,6 +50,3 @@ pub mod unzip;
 pub mod url;
 #[cfg(feature = "worleynoise")]
 pub mod worleynoise;
-
-#[cfg(not(target_pointer_width = "32"))]
-compile_error!("rust-g must be compiled for a 32-bit target");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![forbid(unsafe_op_in_unsafe_fn)]
-#![feature(local_key_cell_methods)]
 
 #[macro_use]
 mod byond;


### PR DESCRIPTION
Adds IconForge, a new module for building asset spritesheets.

It's over 10x faster than BYOND in some cases. This module just takes a JSON input and spits out a spritesheet to a path, so it's up to the DM side to actually use it correctly, but I've tested it with a branch on Bee: https://github.com/itsmeowForks/BeeStation-Hornet/tree/asset-rustg

It is *quite* fast.
![image](https://github.com/tgstation/rust-g/assets/10366817/39c2ed60-e0f5-464f-9996-1e8f9a6e68d2)

I've also added a panic handler to the core rustg module, since this module is.. ~~prone to panicing~~ Not anymore, but it was useful in testing. This should also help diagnose crashes from within rust-g without needing to take minidumps.

~~In the future I want to add a more advanced caching system to this, but as it is~~, it's already just a faster replacement for the existing spritesheet generation code in DM, and people are interested, so here it is. The way the JSON input is designed allows you to precisely determine if anything has changed, since it only supports DMI+icon_states and not any BYOND /icons. You can basically just hash everything and compare to get better caching.

Also adds a caching validation tool. This hashes all DMIs within the `sprites` object and compares them to a previous one provided by DM. It also provides the hashes as the result of the generate() function when prompted. It is up to DM to do the rest, rustg only provides a fast method for comparing the hashes with parallelism.

Cache validation check doesn't cost too much:
![image](https://github.com/tgstation/rust-g/assets/10366817/fb043d59-6e40-43c8-9c6d-6efa4e5f4900)
