### PR TITLE
add random_replacetext, a replacement for stars()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ all = [
     "batchnoise",
     "hash",
     "pathfinder",
+    "random_replacetext",
     "redis_pubsub",
     "redis_reliablequeue",
     "unzip",
@@ -134,6 +135,7 @@ hash = [
     "serde_json",
 ]
 pathfinder = ["num-integer", "pathfinding", "serde", "serde_json"]
+random_replacetext = ["rand"]
 redis_pubsub = ["flume", "redis", "serde", "serde_json"]
 redis_reliablequeue = ["flume", "redis", "serde", "serde_json"]
 unzip = ["zip", "jobs"]

--- a/dmsrc/random_replacetext.dm
+++ b/dmsrc/random_replacetext.dm
@@ -1,0 +1,1 @@
+#define rustg_random_replacetext(text, probability, replacement) RUSTG_CALL(RUST_G, "random_replacetext")(text, probability, replacement)

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -97,7 +97,7 @@ fn totp_generate_tolerance(
 ) -> Result<String> {
     let mut results: Vec<String> = Vec::new();
     for i in -tolerance..(tolerance + 1) {
-        let result = totp_generate(hex_seed, i.try_into().unwrap(), time_override)?;
+        let result = totp_generate(hex_seed, i.into(), time_override)?;
         results.push(result)
     }
     Ok(serde_json::to_string(&results)?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub mod log;
 pub mod noise_gen;
 #[cfg(feature = "pathfinder")]
 pub mod pathfinder;
+#[cfg(feature = "random_replacetext")]
+pub mod random_replacetext;
 #[cfg(feature = "redis_pubsub")]
 pub mod redis_pubsub;
 #[cfg(feature = "redis_reliablequeue")]

--- a/src/random_replacetext.rs
+++ b/src/random_replacetext.rs
@@ -1,5 +1,5 @@
-use rand::Rng;
 use crate::error::Result;
+use rand::Rng;
 
 byond_fn!(fn random_replacetext(text, prob, rand_char) {
     replacetext(text, prob, rand_char).ok()
@@ -18,8 +18,7 @@ fn replacetext(text: &str, prob_as_str: &str, replacement_str: &str) -> Result<S
 
         if rng.gen_ratio(prob, 100) {
             string_return.push_str(replacement_str);
-        }
-        else {
+        } else {
             string_return.push(character);
         }
 

--- a/src/random_replacetext.rs
+++ b/src/random_replacetext.rs
@@ -1,0 +1,28 @@
+use rand::Rng;
+use crate::error::Result;
+
+byond_fn!(fn random_replacetext(text, prob, rand_char) {
+    replacetext(text, prob, rand_char).ok()
+});
+
+fn replacetext(text: &str, prob_as_str: &str, replacement_str: &str) -> Result<String> {
+    let prob = prob_as_str.parse::<u32>()?;
+    let mut rng = rand::thread_rng();
+    let mut string_return = String::new();
+
+    for character in text.chars() {
+        if character.is_whitespace() { // Skip spaces
+            string_return.push(character);
+            continue;
+        }
+
+        if rng.gen_ratio(prob, 100) {
+            string_return.push_str(replacement_str);
+        }
+        else {
+            string_return.push(character);
+        }
+
+    }
+    Ok(string_return)
+}

--- a/src/random_replacetext.rs
+++ b/src/random_replacetext.rs
@@ -11,7 +11,7 @@ fn replacetext(text: &str, prob_as_str: &str, replacement_str: &str) -> Result<S
     let mut string_return = String::new();
 
     for character in text.chars() {
-        if character.is_whitespace() { // Skip spaces
+        if character.is_whitespace() {
             string_return.push(character);
             continue;
         }

--- a/src/random_replacetext.rs
+++ b/src/random_replacetext.rs
@@ -21,7 +21,6 @@ fn replacetext(text: &str, prob_as_str: &str, replacement_str: &str) -> Result<S
         } else {
             string_return.push(character);
         }
-
     }
     Ok(string_return)
 }


### PR DESCRIPTION
Adds a new function, `random_replacetext()`, which randomly replaces non-whitespace characters in a string with another character. This is to replace the `stars()` function found in every SS13 codebase, which is awfully, awfully slow due to byond's string interning.

Please ignore the overtime values for this, as I simply ran each proc 10,000 times in the same tick.
![image](https://github.com/tgstation/rust-g/assets/75460809/6ff70f7f-026e-47bf-8df6-7e88928f34c6)
