### PR TITLE
Adds batchnoise to the default features set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ tracy_full = { version = "1.7.1", optional = true }
 [features]
 default = [
     "acreplace",
+    "batchnoise",
     "cellularnoise",
     "dmi",
     "file",
@@ -81,7 +82,6 @@ default = [
     "time",
     "toml",
     "url",
-    "batchnoise",
 ]
 
 all = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ default = [
     "time",
     "toml",
     "url",
+    "batchnoise",
 ]
 
 all = [


### PR DESCRIPTION
Simply adds `batchnoise` to the default feature set, as I'm going to need to use it with biome generation on /tg/.

I don't know if I need to do anything else, I don't think that I do, but do let me know in case there IS something else I forgot to do.

PR'd with approval from @LemonInTheDark and @ZeWaka.