### PR TITLE
Add task for building on windows

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,6 +7,19 @@
                 "build",
                 "--target",
                 "i686-pc-windows-msvc",
+            ],
+            "command": "cargo",
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": "build"
+        },
+        {
+            "label": "rust: cargo build (win32, all features)",
+            "args": [
+                "build",
+                "--target",
+                "i686-pc-windows-msvc",
                 "--features",
                 "all",
             ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,9 +5,10 @@
             "label": "rust: cargo build (win32)",
             "args": [
                 "build",
-                "--release",
                 "--target",
-                "i686-pc-windows-msvc"
+                "i686-pc-windows-msvc",
+                "--features",
+                "all",
             ],
             "command": "cargo",
             "problemMatcher": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+        {
+            "label": "rust: cargo build (win32)",
+            "args": [
+                "build",
+                "--release",
+                "--target",
+                "i686-pc-windows-msvc"
+            ],
+            "command": "cargo",
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": "build"
+        },
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ cargo build --release --target i686-unknown-linux-gnu
 
 Windows:
 
+If you are using Visual Studio Code, you may use the `CONTROL + SHIFT + B` hotkey and run the `rust: cargo build (win32)` task.
+
+Alternatively:
 ```sh
 cargo build --release --target i686-pc-windows-msvc
 # output: target/i686-pc-windows-msvc/release/rust_g.dll


### PR DESCRIPTION
Adds a tasks.json containing the build task for 32bit rustg on windows. `CONTROL + SHIFT + B` to build.