### PR TITLE
Add format argument to git revdate ffi

### DIFF
--- a/dmsrc/git.dm
+++ b/dmsrc/git.dm
@@ -2,7 +2,8 @@
 #define rustg_git_revparse(rev) RUSTG_CALL(RUST_G, "rg_git_revparse")(rev)
 
 /**
- * Returns the date of the given revision in the format YYYY-MM-DD.
- * Returns null if the revision is invalid.
+ * Returns the date of the given revision using the provided format.
+ * Defaults to returning %F which is YYYY-MM-DD
  */
-#define rustg_git_commit_date(rev) RUSTG_CALL(RUST_G, "rg_git_commit_date")(rev)
+/proc/rustg_git_commit_date(rev, format = "%F")
+	return RUSTG_CALL("rg_git_commit_date")(rev, format)

--- a/dmsrc/git.dm
+++ b/dmsrc/git.dm
@@ -6,4 +6,4 @@
  * Defaults to returning %F which is YYYY-MM-DD
  */
 /proc/rustg_git_commit_date(rev, format = "%F")
-	return RUSTG_CALL("rg_git_commit_date")(rev, format)
+	return RUSTG_CALL(RUST_G, "rg_git_commit_date")(rev, format)

--- a/src/git.rs
+++ b/src/git.rs
@@ -13,7 +13,7 @@ byond_fn!(fn rg_git_revparse(rev) {
     })
 });
 
-byond_fn!(fn rg_git_commit_date(rev) {
+byond_fn!(fn rg_git_commit_date(rev, format) {
     REPOSITORY.with(|repo| -> Option<String> {
         let repo = repo.as_ref().ok()?;
         let rev = repo.rev_parse_single(rev).ok()?;
@@ -21,6 +21,6 @@ byond_fn!(fn rg_git_commit_date(rev) {
         let commit = object.try_into_commit().ok()?;
         let commit_time = commit.committer().ok()?.time;
         let datetime = Utc.timestamp_opt(commit_time.seconds, 0).latest()?;
-        Some(datetime.format("%F").to_string())
+        Some(datetime.format(format).to_string())
     })
 });


### PR DESCRIPTION
Add the ability to pass a format string, which defaults to pre-existing functionality, to git revdate parsing