### PR TITLE
Updates git log parsing to use .lines() instead of .split('\n') which was returning an empty last item due to trailing newlines

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -27,17 +27,19 @@ byond_fn!(fn rg_git_commit_date(rev, format) {
 });
 
 byond_fn!(fn rg_git_commit_date_head(format) {
-    let head_log_path = Path::new(".git")
-        .join("logs")
-        .join("HEAD");
+    let head_log_path = Path::new(".git").join("logs").join("HEAD");
     let head_log = fs::metadata(&head_log_path).ok()?;
     if !head_log.is_file() {
         return None;
     }
     let log_entries = fs::read_to_string(&head_log_path).ok()?;
-    let log_entries = log_entries.split('\n');
-    let last_entry = log_entries.last()?.split_ascii_whitespace().collect::<Vec<_>>();
-    if last_entry.len() < 5 { // 5 is the timestamp
+    let log_entries = log_entries.lines();
+    let last_entry = log_entries
+        .last()?
+        .split_ascii_whitespace()
+        .collect::<Vec<_>>();
+    if last_entry.len() < 5 {
+        // 5 is the timestamp
         return None;
     }
     let datetime = Utc.timestamp_opt(last_entry[4].parse().ok()?, 0).latest()?;


### PR DESCRIPTION
I tested this locally with a manually edited .git folder but not with an actual test environment