### PR TITLE
Compiling error reworks. allow 64 with feature, block newer rustc without a feature.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.75
         with:
           targets: i686-pc-windows-msvc
           components: rustfmt, clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,6 +2958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,8 @@ dmi = { version = "0.3.5", optional = true }
 tracy_full = { version = "1.8.0", optional = true }
 ammonia = { version = "4.0.0", optional = true }
 fast_poisson = { version = "0.5.2", optional = true, features = ["single_precision"]} # Higher versions have problems with x86 due to 'kiddo'.
+rustversion = "1.0"
+
 
 [features]
 default = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,8 @@ rustls_tls = ["mysql/default-rustls"]
 
 # internal feature-like things
 jobs = ["flume"]
+allow_non_32bit = []
+allow_non_windows7 = []
 
 [dev-dependencies]
 regex = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,8 @@ pub mod url;
 #[cfg(feature = "worleynoise")]
 pub mod worleynoise;
 
-#[cfg(all(rustversion::since(1.76), not(feature = "allow_non_windows7")))]
-compile_error!("Compiling under rustc 1.76 or newer is not allowed without enabling the `allow_non_windows7` feature ");
+#[cfg(all(rustversion::since(1.78), not(feature = "allow_non_windows7")))]
+compile_error!("Compiling under rustc 1.78 or newer is not allowed without enabling the `allow_non_windows7` feature ");
 
 
 #[cfg(all(not(target_pointer_width = "32"), not(feature = "allow_non_32bit")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,3 +54,10 @@ pub mod unzip;
 pub mod url;
 #[cfg(feature = "worleynoise")]
 pub mod worleynoise;
+
+#[cfg(all(rustversion::since(1.76), not(feature = "allow_non_windows7")))]
+compile_error!("Compiling under rustc 1.76 or newer is not allowed without enabling the `allow_non_windows7` feature ");
+
+
+#[cfg(all(not(target_pointer_width = "32"), not(feature = "allow_non_32bit")))]
+compile_error!("Compiling for non-32bit is not allowed without enabling the `allow_non_32bit` feature.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,3 @@ pub mod unzip;
 pub mod url;
 #[cfg(feature = "worleynoise")]
 pub mod worleynoise;
-
-#[cfg(not(target_pointer_width = "32"))]
-compile_error!("rust-g must be compiled for a 32-bit target");


### PR DESCRIPTION
Adds features that to allow compiling under 64 bit or a rustc version that is too new for windows 7 and 8 (note, the game servers are still windows server 2012, so rustc dropping windows 8 support under 1.76 will also fuck prod.)

Compiling under 64bit is required for OD support and this has turned from an error that was suppose to prevent footguns into an error that is itself a footgun.