### PR TITLE
Fix a panic in `byond::parse_args` with debug assertions

### DIFF
--- a/src/byond.rs
+++ b/src/byond.rs
@@ -18,6 +18,9 @@ thread_local! {
 }
 
 pub unsafe fn parse_args<'a>(argc: c_int, argv: *const *const c_char) -> Vec<Cow<'a, str>> {
+    if argc == 0 || argv.is_null() {
+        return Vec::new();
+    }
     unsafe {
         slice::from_raw_parts(argv, argc as usize)
             .iter()


### PR DESCRIPTION
The same issue from https://github.com/willox/auxtools/issues/90 is likely present here, due to the use of the same code - so I ported my same fix (from https://github.com/willox/auxtools/pull/93/commits/b1f474ba68ba5a8cd1363705de03ff94c317c44a)