### PR TITLE
Add hash and iconforge as default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,9 @@ default = [
     "dmi",
     "file",
     "git",
+    "hash",
     "http",
+    "iconforge",
     "json",
     "log",
     "noise",
@@ -96,7 +98,9 @@ all = [
     "dmi",
     "file",
     "git",
+    "hash",
     "http",
+    "iconforge",
     "json",
     "log",
     "noise",
@@ -107,8 +111,6 @@ all = [
     "time",
     "toml",
     "url",
-    "hash",
-    "iconforge",
     "pathfinder",
     "poissonnoise",
     "redis_pubsub",
@@ -124,17 +126,6 @@ cellularnoise = ["rand", "rayon"]
 dmi = ["png", "image", "dep:dmi"]
 file = []
 git = ["gix", "chrono"]
-http = ["ureq", "serde", "serde_json", "once_cell", "jobs"]
-json = ["serde", "serde_json"]
-log = ["chrono"]
-sanitize = ["ammonia", "serde_json"]
-sound_len = ["symphonia"]
-sql = ["mysql", "serde", "serde_json", "once_cell", "dashmap", "jobs"]
-time = []
-toml = ["serde", "serde_json", "toml-dep"]
-url = ["url-dep", "percent-encoding"]
-
-# additional features
 hash = [
     "base64",
     "const-random",
@@ -146,6 +137,7 @@ hash = [
     "serde",
     "serde_json",
 ]
+http = ["ureq", "serde", "serde_json", "once_cell", "jobs"]
 iconforge = [
     "dashmap",
     "dep:dmi",
@@ -160,6 +152,16 @@ iconforge = [
     "tracy_full",
     "twox-hash",
 ]
+json = ["serde", "serde_json"]
+log = ["chrono"]
+sanitize = ["ammonia", "serde_json"]
+sound_len = ["symphonia"]
+sql = ["mysql", "serde", "serde_json", "once_cell", "dashmap", "jobs"]
+time = []
+toml = ["serde", "serde_json", "toml-dep"]
+url = ["url-dep", "percent-encoding"]
+
+# additional features
 pathfinder = ["num-integer", "pathfinding", "serde", "serde_json"]
 poissonnoise = ["fast_poisson"]
 redis_pubsub = ["flume", "redis", "serde", "serde_json"]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ The default features are:
   Mostly used by the asset cache subsystem to improve load times.
 * file: Faster replacements for `file2text` and `text2file`, as well as reading or checking if files exist.
 * git: Functions for robustly checking the current git revision.
+* hash: Faster replacement for `md5`, support for SHA-1, SHA-256, and SHA-512. Requires OpenSSL on Linux.
 * http: Asynchronous HTTP(s) client supporting most standard methods.
+* iconforge: A much faster replacement for the spritesheet generation system used by [/tg/station].
 * json: Function to check JSON validity.
 * log: Faster log output.
 * noise: 2d Perlin noise.
@@ -110,8 +112,6 @@ The default features are:
 Additional features are:
 * allow_non_32bit: Disables the forced compile errors on non-32bit targets. Only use this if you know exactly what you are doing.
 * batchnoise: Discrete Batched Perlin-like Noise, fast and multi-threaded - sent over once instead of having to query for every tile.
-* hash: Faster replacement for `md5`, support for SHA-1, SHA-256, and SHA-512. Requires OpenSSL on Linux.
-* iconforge: A much faster replacement for the spritesheet generation system used by [/tg/station].
 * pathfinder: An a* pathfinder used for finding the shortest path in a static node map. Not to be used for a non-static map.
 * poissonnoise: A way to generate a 2D poisson disk distribution ('blue noise'), which is relatively uniform.
 * redis_pubsub: Library for sending and receiving messages through Redis.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The default features are:
   Mostly used by the asset cache subsystem to improve load times.
 * file: Faster replacements for `file2text` and `text2file`, as well as reading or checking if files exist.
 * git: Functions for robustly checking the current git revision.
-* hash: Faster replacement for `md5`, support for SHA-1, SHA-256, and SHA-512. Requires OpenSSL on Linux.
+* hash: Faster replacement for `md5`, support for SHA-1, SHA-256, and SHA-512.
 * http: Asynchronous HTTP(s) client supporting most standard methods.
 * iconforge: A much faster replacement for the spritesheet generation system used by [/tg/station].
 * json: Function to check JSON validity.


### PR DESCRIPTION
Adds `hash` and `iconforge` as default features so they can be used on /tg/ including in the CI process (since embedding an 82MB .so file into the repo is unlikely, and building the binary in CI is slow)