### PR TITLE
IconForge: Sort GAGS output states

### DIFF
--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -1225,7 +1225,10 @@ fn gags(config_path: &str, colors: &str, output_dmi_path: &str) -> Result<String
     {
         zone!("gags_sort_states");
         // This is important, because it allows GAGS icons to be included inside of caches - they will output in the same order between runs.
-        output_states.lock().unwrap().sort_unstable_by(|state1, state2| state1.name.cmp(&state2.name))
+        output_states
+            .lock()
+            .unwrap()
+            .sort_unstable_by(|state1, state2| state1.name.cmp(&state2.name))
     }
 
     {

--- a/src/iconforge.rs
+++ b/src/iconforge.rs
@@ -1223,6 +1223,12 @@ fn gags(config_path: &str, colors: &str, output_dmi_path: &str) -> Result<String
     }
 
     {
+        zone!("gags_sort_states");
+        // This is important, because it allows GAGS icons to be included inside of caches - they will output in the same order between runs.
+        output_states.lock().unwrap().sort_unstable_by(|state1, state2| state1.name.cmp(&state2.name))
+    }
+
+    {
         zone!("gags_write_dmi");
         let path = std::path::Path::new(output_dmi_path);
         std::fs::create_dir_all(path.parent().unwrap())?;


### PR DESCRIPTION
Sorts the output icon states by name before they're written to the disk. This ensures that GAGS icons can be used within spritesheet caches without incorrectly invalidating due to the random order of parallelization.