### PR TITLE
DMI generation function and helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,6 +2504,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_repr",
  "sha-1",
  "sha2",
  "symphonia",
@@ -2686,6 +2687,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ redis = { version = "0.29", optional = true, features = ["ahash"] }
 ureq = { version = "2.12", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
+serde_repr = { version = "0.1", optional = true }
 once_cell = { version = "1.20", optional = true }
 mysql = { git = "https://github.com/ZeWaka/rust-mysql-simple.git", tag = "v26.0.0", default-features = false, optional = true }
 dashmap = { version = "6.1", optional = true, features = ["rayon", "serde"] }
@@ -64,9 +65,7 @@ ammonia = { version = "4.0.0", optional = true }
 fast_poisson = { version = "=0.5.2", optional = true, features = [
     "single_precision",
 ] } # Higher versions have problems with x86 due to 'kiddo'.
-symphonia = { version = "0.5.4", optional = true, features = [
-    "all-codecs",
-] }
+symphonia = { version = "0.5.4", optional = true, features = ["all-codecs"] }
 
 [features]
 default = [
@@ -123,7 +122,7 @@ all = [
 acreplace = ["aho-corasick"]
 batchnoise = ["dbpnoise"]
 cellularnoise = ["rand", "rayon"]
-dmi = ["png", "image", "dep:dmi"]
+dmi = ["png", "image", "dep:dmi", "serde_repr"]
 file = []
 git = ["gix", "chrono"]
 hash = [

--- a/dmsrc/dmi.dm
+++ b/dmsrc/dmi.dm
@@ -7,3 +7,43 @@
  * output: json_encode'd list. json_decode to get a flat list with icon states in the order they're in inside the .dmi
  */
 #define rustg_dmi_icon_states(fname) RUSTG_CALL(RUST_G, "dmi_icon_states")(fname)
+
+/**
+ * Flattens a list of pixel layers into a single layer by blending the colors of each layer.
+ * Colors are blended with the first layer on the bottom, and each successive layer on top of the previous one.
+ *
+ * `data` is a a json_encoded list of lists of hexadecimal color strings (null is treated as #00000000)
+ *
+ * Returns a json_encode'd list as long as the longest layer in `data`
+ */
+#define rustg_dmi_flatten_layers(data) RUSTG_CALL(RUST_G, "dmi_flatten_layers")(data)
+
+/**
+ * Generates a dmi file at the specified path.
+ *
+ * "data" format:
+ * list(
+ *      "width": number
+ *      "height": number
+ *      "states": [STATE][]
+ * )
+ *
+ * STATE format:
+ * list(
+ *     "name": string
+ *     "dirs": 1 | 4 | 8
+ *     "delay"?: number[]
+ *     "rewind": boolean
+ *     "movement": boolean
+ *     "loop"?: number
+ *     "pixels": string[]
+ * )
+ *
+ * STATE["pixels"] is a list of pixels flattened to one dimension.
+ * A single pixel is represented by a hexadecimal color string with an optional alpha channel (null is treated as #00000000).
+ * A single row consists of `width` pixels.
+ * A single dir-frame consists of `height` rows.
+ * A single frame consists of `dirs` dir-frames, in the order [SOUTH, NORTH, EAST, WEST, SOUTHEAST, SOUTHWEST, NORTHEAST, NORTHWEST].
+ * A single state consists of one frame for each number in `delay`, or a single frame if `delay` is not present.
+ */
+#define rustg_dmi_create_dmi(path, data) RUSTG_CALL(RUST_G, "dmi_create_dmi")(path, data)

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -1,9 +1,13 @@
 use crate::error::{Error, Result};
-use dmi::icon::Icon;
+use dmi::icon::{DmiVersion, Icon, IconState, Looping};
+use image::{DynamicImage, GenericImage, Pixel, Rgba, RgbaImage};
 use png::{Decoder, Encoder, OutputInfo, Reader};
+use serde::Deserialize;
+use serde_repr::Deserialize_repr;
 use std::{
     fs::{create_dir_all, File},
     io::BufReader,
+    num::NonZeroU32,
     path::Path,
 };
 
@@ -135,4 +139,163 @@ fn read_states(path: &str) -> Result<String> {
         .map(|s| s.name.clone())
         .collect();
     Ok(serde_json::to_string(&states)?)
+}
+
+byond_fn!(fn dmi_flatten_layers(data) {
+    flatten_layers(data).ok()
+});
+
+fn flatten_layers(data: &str) -> Result<String> {
+    let layers: Vec<Vec<Option<String>>> = serde_json::from_str(data)?;
+    let mut out_layer: Vec<Rgba<u8>> = vec![];
+    out_layer.resize(
+        layers.iter().fold(0, |max, layer| max.max(layer.len())),
+        Rgba::<u8>([0, 0, 0, 0]),
+    );
+    for layer in layers {
+        for (i, pixel_opt) in layer.iter().enumerate() {
+            if let Some(pixel) = pixel_opt {
+                let mut samples: Vec<u8> = vec![];
+                let pixel_bytes: Vec<u8> = pixel.bytes().skip(1).collect();
+                for chunk in pixel_bytes.as_slice().chunks_exact(2) {
+                    samples.push(u8::from_str_radix(std::str::from_utf8(chunk)?, 16)?);
+                }
+                samples.resize(4, 0);
+                out_layer[i].blend(Rgba::from_slice(samples.as_slice()));
+            }
+        }
+    }
+    Ok(serde_json::to_string(
+        &out_layer
+            .iter()
+            .map(|Rgba([r, g, b, a])| {
+                if *a < u8::MAX {
+                    format!("#{r:02X?}{g:02X?}{b:02X?}{a:02X?}")
+                } else {
+                    format!("#{r:02X?}{g:02X?}{b:02X?}")
+                }
+            })
+            .collect::<Vec<String>>(),
+    )?)
+}
+
+#[derive(Deserialize_repr, Clone, Copy)]
+#[repr(u8)]
+enum DmiBuldStateDirCount {
+    One = 1,
+    Four = 4,
+    Eight = 8,
+}
+
+#[derive(Deserialize)]
+struct DmiBuildState {
+    name: String,
+    dirs: DmiBuldStateDirCount,
+    #[serde(default)]
+    delay: Option<Vec<f32>>,
+    #[serde(default)]
+    rewind: Option<u8>,
+    #[serde(default)]
+    movement: Option<u8>,
+    #[serde(default)]
+    loop_count: Option<NonZeroU32>,
+    pixels: Vec<Option<String>>,
+}
+
+#[derive(Deserialize)]
+struct DmiBuildParams {
+    width: u32,
+    height: u32,
+    states: Vec<DmiBuildState>,
+}
+
+byond_fn!(fn dmi_create_dmi(out_path, params_string) {
+    create_dmi(out_path, params_string).err()
+});
+
+fn create_dmi(out_path: &str, params_string: &str) -> Result<()> {
+    let DmiBuildParams {
+        width,
+        height,
+        states,
+    } = serde_json::from_str(params_string)?;
+    let sprite_size = (width * height) as usize;
+    if sprite_size == 0 {
+        return Err(Error::ZeroIconSize);
+    }
+    if states.is_empty() {
+        return Err(Error::NoDmiStates);
+    };
+    let mut out_icon = Icon {
+        version: DmiVersion::default(),
+        width,
+        height,
+        states: vec![],
+    };
+    for DmiBuildState {
+        name,
+        dirs,
+        delay,
+        loop_count,
+        rewind,
+        movement,
+        pixels,
+    } in states
+    {
+        let frame_count = delay.as_ref().map_or(1, |delays| delays.len());
+        let pixel_count = pixels.len();
+        let expected_pixel_count = frame_count * sprite_size;
+        if pixel_count != expected_pixel_count {
+            return Err(Error::StateDataFormat(
+                name,
+                format!("Expected {expected_pixel_count} pixels, got {pixel_count}"),
+            ));
+        };
+        let mut out_state = IconState {
+            name: name.clone(),
+            dirs: dirs as u8,
+            frames: frame_count as u32,
+            images: vec![],
+            delay,
+            loop_flag: loop_count.map_or(Looping::Indefinitely, Looping::NTimes),
+            rewind: rewind.is_some_and(|r| r != 0),
+            movement: movement.is_some_and(|m| m != 0),
+            hotspot: None,
+            unknown_settings: None,
+        };
+        for chunk in pixels.chunks_exact(sprite_size) {
+            let mut image = DynamicImage::ImageRgba8(RgbaImage::from_pixel(
+                width,
+                height,
+                Rgba([192, 192, 192, 0]),
+            ));
+            for (i, pixel_opt) in chunk.iter().enumerate() {
+                if let Some(pixel) = pixel_opt {
+                    let mut samples: Vec<u8> = vec![];
+                    let pixel_bytes: Vec<u8> = pixel.bytes().skip(1).collect();
+                    for chunk in pixel_bytes.as_slice().chunks_exact(2) {
+                        samples.push(u8::from_str_radix(std::str::from_utf8(chunk)?, 16)?);
+                    }
+                    match samples.len() {
+                        3 => samples.push(u8::MAX),
+                        4 if samples[3] == 0 => continue,
+                        4 => (),
+                        _ => {
+                            return Err(Error::StateDataFormat(
+                                name,
+                                format!("Invalid color string \"{pixel}\" at index {i} (must be an RGB or RGBA hex color string)"),
+                            ))
+                        }
+                    }
+                    let x = i as u32 % width;
+                    let y = i as u32 / width;
+                    image.put_pixel(x, y, Rgba([samples[0], samples[1], samples[2], samples[3]]));
+                }
+            }
+            out_state.images.push(image);
+        }
+        out_icon.states.push(out_state);
+    }
+    out_icon.save(&mut File::create(out_path)?)?;
+    Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use dmi::error::DmiError;
 use std::{
     io,
     num::{ParseFloatError, ParseIntError},
@@ -70,6 +71,15 @@ pub enum Error {
     IconForge(String),
     #[error("Panic during function execution: {0}")]
     Panic(String),
+    #[error("Build params have zero width/height")]
+    ZeroIconSize,
+    #[error("No state data in build params.")]
+    NoDmiStates,
+    #[error("Incorrect data for state \"{0}\": {1}")]
+    StateDataFormat(String, String),
+    #[cfg(feature = "dmi")]
+    #[error(transparent)]
+    Dmi(#[from] DmiError),
 }
 
 impl From<Utf8Error> for Error {


### PR DESCRIPTION
This PR adds a function for generating a dmi from state data and pixel data. This is far faster than manually calling DM's own icon editing procs for generating most icons, and supports directional icons, animated icons, and transparency, unlike `dmi_create_png`.

Also adds a function that blends multiple layers of pixels, first to last. For cases like in-game sprite editing (which is what this PR is for), blending multiple layers of hundreds of pixels in DM could get expensive enough to cause some amount of lag.