### PR TITLE
Adds a new time function, `formatted_timestamp`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ log = ["chrono"]
 sanitize = ["ammonia", "serde_json"]
 sound_len = ["symphonia"]
 sql = ["mysql", "serde", "serde_json", "once_cell", "dashmap", "jobs"]
-time = []
+time = ["chrono"]
 toml = ["serde", "serde_json", "toml-dep"]
 url = ["url-dep", "percent-encoding"]
 

--- a/dmsrc/time.dm
+++ b/dmsrc/time.dm
@@ -1,6 +1,8 @@
 #define rustg_time_microseconds(id) text2num(RUSTG_CALL(RUST_G, "time_microseconds")(id))
 #define rustg_time_milliseconds(id) text2num(RUSTG_CALL(RUST_G, "time_milliseconds")(id))
 #define rustg_time_reset(id) RUSTG_CALL(RUST_G, "time_reset")(id)
+#define rustg_formatted_timestamp(format) RUSTG_CALL(RUST_G, "formatted_timestamp")(format)
+#define rustg_formatted_timestamp_tz(format, offset) RUSTG_CALL(RUST_G, "formatted_timestamp")(format, offset)
 
 /// Returns the timestamp as a string
 /proc/rustg_unix_timestamp()

--- a/dmsrc/time.dm
+++ b/dmsrc/time.dm
@@ -1,7 +1,13 @@
 #define rustg_time_microseconds(id) text2num(RUSTG_CALL(RUST_G, "time_microseconds")(id))
 #define rustg_time_milliseconds(id) text2num(RUSTG_CALL(RUST_G, "time_milliseconds")(id))
 #define rustg_time_reset(id) RUSTG_CALL(RUST_G, "time_reset")(id)
+
+/// Returns the current timestamp (in local time), formatted with the given format string.
+/// See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for documentation on the formatting syntax.
 #define rustg_formatted_timestamp(format) RUSTG_CALL(RUST_G, "formatted_timestamp")(format)
+
+/// Returns the current timestamp (with the given UTC offset in hours), formatted with the given format string.
+/// See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for documentation on the formatting syntax.
 #define rustg_formatted_timestamp_tz(format, offset) RUSTG_CALL(RUST_G, "formatted_timestamp")(format, offset)
 
 /// Returns the timestamp as a string

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,3 +1,4 @@
+use chrono::{FixedOffset, Local, Utc};
 use std::{
     cell::RefCell,
     collections::hash_map::{Entry, HashMap},
@@ -47,3 +48,24 @@ byond_fn!(
         ))
     }
 );
+
+byond_fn!(
+    fn formatted_timestamp(format, offset) {
+        format_timestamp(format, offset)
+    }
+);
+
+fn format_timestamp(format: &str, offset: &str) -> Option<String> {
+    if offset.is_empty() {
+        Some(Local::now().format(format).to_string())
+    } else {
+        let offset_seconds = offset.parse::<i32>().ok()? * 3600;
+        let timezone = FixedOffset::east_opt(offset_seconds)?;
+        Some(
+            Utc::now()
+                .with_timezone(&timezone)
+                .format(format)
+                .to_string(),
+        )
+    }
+}


### PR DESCRIPTION
This adds a simple function, `formatted_offset`

It is basically just a wrapper around [chrono's formatting](https://docs.rs/chrono/0.4.41/chrono/format/strftime/index.html), and takes two args: a format, and an optional offset

If the offset is blank, then the system's local time will be used, in order to stay consistent with the behavior of BYOND's `time2text` - otherwise, an offset from UTC in hours can be given.


basically this is better `time2text`, with subsecond support and such