### PR TITLE
Enable pathfinder by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "rust-g"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "aho-corasick",
  "ammonia",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-g"
 edition = "2021"
-version = "3.9.0"
+version = "3.10.0"
 authors = [
     "Bjorn Neergaard <bjorn@neersighted.com>",
     "Tad Hardesty <tad@platymuus.com>",
@@ -64,9 +64,7 @@ ammonia = { version = "4.1", optional = true }
 fast_poisson = { version = "=0.5.2", optional = true, features = [
     "single_precision",
 ] } # Higher versions have problems with x86 due to 'kiddo'.
-symphonia = { version = "0.5.4", optional = true, features = [
-    "all-codecs",
-] }
+symphonia = { version = "0.5.4", optional = true, features = ["all-codecs"] }
 
 [features]
 default = [
@@ -82,6 +80,7 @@ default = [
     "json",
     "log",
     "noise",
+    "pathfinder",
     "rustls_tls",
     "sanitize",
     "sound_len",

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The default features are:
 * json: Function to check JSON validity.
 * log: Faster log output.
 * noise: 2d Perlin noise.
+* pathfinder: An a* pathfinder used for finding the shortest path in a static node map. Not to be used for a non-static map.
 * sound_len: A mostly codec-agnostic library for reading the duration of an audio file.
 * sql: Asynchronous MySQL/MariaDB client library.
   * There are also two sub-features: `native_tls` and `rustls_tls`. `rustls_tls` is a default feature, while the former is not.
@@ -113,7 +114,6 @@ The default features are:
 Additional features are:
 * allow_non_32bit: Disables the forced compile errors on non-32bit targets. Only use this if you know exactly what you are doing.
 * batchnoise: Discrete Batched Perlin-like Noise, fast and multi-threaded - sent over once instead of having to query for every tile.
-* pathfinder: An a* pathfinder used for finding the shortest path in a static node map. Not to be used for a non-static map.
 * poissonnoise: A way to generate a 2D poisson disk distribution ('blue noise'), which is relatively uniform.
 * redis_pubsub: Library for sending and receiving messages through Redis.
 * redis_reliablequeue: Library for using a reliable queue pattern through Redis.


### PR DESCRIPTION
Trying to get TGMC to use the uploaded binaries because right now it's building the entire thing just for pathfinder. I considered getting TGMC on a cache but frankly I have been over this features split for a long time. The intent was to limit the loaded rust-g DLL's impact on the BYOND memory limit but that was dramatically raised to a point that we no longer care about it