### PR TITLE
Improve DM test functionality on Windows, fix regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 
 /target
 **/*.rs.bk
+tests/dm/*.dmb
+tests/dm/*.lk
+tests/dm/*.int
+tests/dm/*.rsc
+tests/dm/tmp/
+tests/dm/*.dll
+tests/dm/*.so
+tests/dm/rust_g.dm

--- a/tests/abc-tests.rs
+++ b/tests/abc-tests.rs
@@ -50,7 +50,7 @@ fn test_librs() -> Result<(), String> {
 #[test]
 fn test_cargotoml() -> Result<(), String> {
     let cargotoml = std::fs::read_to_string("Cargo.toml").unwrap();
-    let blocksre = RegexBuilder::new(r"^# default features\r?\n((:?^.+?\r?\n)*)\r?\n# additional features\r?\n((:?^.+?\r?\n)*)\r?\n#").multi_line(true).build().unwrap();
+    let blocksre = RegexBuilder::new(r"^# default features\r?\n((:?^[^#\r\n]+?\r?\n)*)\r?\n# additional features\r?\n((:?^[^#\r\n]+?\r?\n)*)\r?\n#").multi_line(true).build().unwrap();
     let linesre = RegexBuilder::new(r"^(\w.+?)$")
         .multi_line(true)
         .build()

--- a/tests/dm-tests.rs
+++ b/tests/dm-tests.rs
@@ -62,7 +62,6 @@ fn compile_and_run_dme(name: &str, rust_g_lib_path: &str, chdir: Option<&str>) -
 
     let dme = format!("tests/dm/{name}.dme");
     let dmb = format!("tests/dm/{name}.dmb");
-    let rsc = format!("tests/dm/{name}.rsc");
 
     let output = Command::new(&dream_maker).arg(&dme).output().unwrap();
     dump(&output);
@@ -76,8 +75,13 @@ fn compile_and_run_dme(name: &str, rust_g_lib_path: &str, chdir: Option<&str>) -
         .env("RUST_G", rust_g_lib_path)
         .output()
         .unwrap();
+
+    // Cleanup
     let _ = std::fs::remove_file(&dmb);
-    let _ = std::fs::remove_file(&rsc);
+    let _ = std::fs::remove_file(&format!("tests/dm/{name}.rsc"));
+    let _ = std::fs::remove_file(&format!("tests/dm/{name}.dyn.rsc"));
+    let _ = std::fs::remove_file(&format!("tests/dm/{name}.lk"));
+    let _ = std::fs::remove_file(&format!("tests/dm/{name}.int"));
 
     dump(&output);
     generic_check(&output);

--- a/tests/dm-tests.rs
+++ b/tests/dm-tests.rs
@@ -1,80 +1,148 @@
+use std::fs;
+use std::path::Path;
 use std::process::{Command, Output};
 
 #[cfg(feature = "git")]
 #[test]
 fn git() {
-    run_dm_tests("git");
+    run_dm_tests("git", true);
 }
 
 #[cfg(feature = "toml")]
 #[test]
 fn toml() {
-    run_dm_tests("toml");
+    run_dm_tests("toml", false);
 }
 
 #[cfg(feature = "url")]
 #[test]
 fn url() {
-    run_dm_tests("url");
+    run_dm_tests("url", false);
 }
 
 #[cfg(feature = "hash")]
 #[test]
 fn hash() {
-    run_dm_tests("hash");
+    run_dm_tests("hash", false);
 }
 
-fn run_dm_tests(name: &str) {
-    std::env::remove_var("RUST_BACKTRACE");
+/**
+ * Find a valid BYOND bin path on the system.
+ */
+fn find_byond() -> String {
+    return match std::env::var("BYOND_BIN") {
+        Ok(bin) => bin,
+        Err(_) => {
+            let paths = vec![
+                "C:/Program Files (x86)/BYOND/bin",
+                "C:/Program Files/BYOND/bin",
+            ];
+            let mut found_path = None;
+            for path in paths {
+                if let Ok(exists) = fs::exists(Path::new(path)) {
+                    if exists {
+                        found_path = Some(path.to_string());
+                        break;
+                    } else {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+            }
+            found_path.expect("Could not find environment variable BYOND_BIN, or any valid installation path for BYOND.")
+        }
+    };
+}
 
-    let byond_bin = std::env::var("BYOND_BIN").expect("environment variable BYOND_BIN");
-    let byondexec = format!("{byond_bin}/byondexec");
-    let dream_maker = format!("{byond_bin}/DreamMaker");
-    let dream_daemon = format!("{byond_bin}/DreamDaemon");
+fn compile_and_run_dme(name: &str, rust_g_lib_path: &str, chdir: Option<&str>) -> Output {
+    let byond_bin = find_byond();
+    let dream_maker = format!("{byond_bin}/dm");
+    let dream_daemon = format!("{byond_bin}/dd");
 
     let dme = format!("tests/dm/{name}.dme");
     let dmb = format!("tests/dm/{name}.dmb");
+    let rsc = format!("tests/dm/{name}.rsc");
 
+    let output = Command::new(&dream_maker).arg(&dme).output().unwrap();
+    dump(&output);
+    generic_check(&output);
+
+    let output = Command::new(&dream_daemon)
+        .arg(&dmb)
+        .arg("-trusted")
+        .arg("-cd")
+        .arg(if let Some(dir) = chdir { dir } else { "." })
+        .env("RUST_G", rust_g_lib_path)
+        .output()
+        .unwrap();
+    let _ = std::fs::remove_file(&dmb);
+    let _ = std::fs::remove_file(&rsc);
+
+    dump(&output);
+    generic_check(&output);
+    output
+}
+
+/**
+ * Find the rust_g binary and DMSRC and copy them into the test run directory
+ */
+fn find_and_copy_rustg_lib() -> (String, &'static str, &'static str) {
     let target_dir = if cfg!(target_os = "linux") {
         "i686-unknown-linux-gnu"
     } else {
-        "i686-pc-windows-gnu"
+        "i686-pc-windows-msvc"
     };
     let profile = if cfg!(debug_assertions) {
         "debug"
     } else {
         "release"
     };
-    let fname = if cfg!(target_os = "linux") {
+    let rustg_lib_fname = if cfg!(target_os = "linux") {
         "librust_g.so"
     } else {
         "rust_g.dll"
     };
-    let rust_g = format!("target/{target_dir}/{profile}/{fname}");
+    let rustg_lib_source_path = format!("target/{target_dir}/{profile}/{rustg_lib_fname}");
+    println!("Source RUST_G path: {rustg_lib_source_path}");
+    match fs::exists(Path::new(&rustg_lib_source_path)) {
+        Ok(exists) => {
+            if !exists {
+                panic!("Source RUST_G path does not exist! Try rebuilding the project with the corresponding target and debug or release mode.")
+            }
+        }
+        Err(err) => panic!("Error accessing source rust_g path! {err}"),
+    }
+    let rustg_lib_path = format!("tests/dm/{rustg_lib_fname}");
+    let _ = fs::copy(&rustg_lib_source_path, &rustg_lib_path);
+    let rustg_dm_path = "tests/dm/rust_g.dm";
+    let _ = fs::copy("target/rust_g.dm", rustg_dm_path);
+    (rustg_lib_path, rustg_lib_fname, rustg_dm_path)
+}
 
-    let output = Command::new("bash")
-        .arg(&byondexec)
-        .arg(&dream_maker)
-        .arg(&dme)
-        .output()
-        .unwrap();
-    dump(&output);
-    generic_check(&output);
+fn run_dm_tests(name: &str, use_repo_root: bool) {
+    std::env::remove_var("RUST_BACKTRACE");
 
-    let output = Command::new("bash")
-        .arg(&byondexec)
-        .arg(&dream_daemon)
-        .arg(&dmb)
-        .arg("-trusted")
-        .arg("-cd")
-        .arg(env!("CARGO_MANIFEST_DIR"))
-        .env("RUST_G", &rust_g)
-        .output()
-        .unwrap();
-    let _ = std::fs::remove_file(&dmb);
-    dump(&output);
-    generic_check(&output);
+    let (rustg_lib_path, rustg_lib_fname, rustg_dm_path) = find_and_copy_rustg_lib();
+
+    let output = compile_and_run_dme(
+        &name,
+        if use_repo_root {
+            &rustg_lib_path
+        } else {
+            rustg_lib_fname
+        },
+        if use_repo_root {
+            Some(env!("CARGO_MANIFEST_DIR"))
+        } else {
+            None
+        },
+    );
     runtime_check(&output);
+
+    // Cleanup
+    let _ = std::fs::remove_file(&rustg_lib_path);
+    let _ = std::fs::remove_file(&rustg_dm_path);
 }
 
 fn dump(output: &Output) {

--- a/tests/dm/common.dm
+++ b/tests/dm/common.dm
@@ -1,5 +1,5 @@
 #define RUST_G world.GetConfig("env", "RUST_G")
-#include "../../target/rust_g.dm"
+#include "rust_g.dm"
 
 /world/New()
     for(var/func in typesof(/test/proc))

--- a/tests/dm/toml.dme
+++ b/tests/dm/toml.dme
@@ -13,17 +13,17 @@ var/test_json = @{"
 "}
 
 /test/proc/check_toml_file2json()
-    rustg_file_write(test_toml, "test.toml")
+    rustg_file_write(test_toml, "tmp/test.toml")
 
-    var/toml_output = rustg_read_toml_file("test.toml")
+    var/toml_output = rustg_read_toml_file("tmp/test.toml")
 
     if (toml_output ~! json_decode(test_json))
         CRASH("test:\n[test_toml]\n \nexpected:\n[test_json]\n \nrustg:\n[json_encode(toml_output)]")
 
 /test/proc/check_rustg_toml_encode()
     var/json_value = json_decode(test_json)
-    rustg_file_write(rustg_toml_encode(json_value), "test_encode.toml")
-    var/toml_output = rustg_read_toml_file("test_encode.toml")
+    rustg_file_write(rustg_toml_encode(json_value), "tmp/test_encode.toml")
+    var/toml_output = rustg_read_toml_file("tmp/test_encode.toml")
 
     if (toml_output ~! json_value)
         CRASH("test:\n[test_toml]\n \nexpected:\n[test_json]\n \nrustg:\n[json_encode(toml_output)]")

--- a/tests/dm/toml.dme
+++ b/tests/dm/toml.dme
@@ -16,6 +16,7 @@ var/test_json = @{"
     rustg_file_write(test_toml, "tmp/test.toml")
 
     var/toml_output = rustg_read_toml_file("tmp/test.toml")
+    fdel("tmp/test.toml")
 
     if (toml_output ~! json_decode(test_json))
         CRASH("test:\n[test_toml]\n \nexpected:\n[test_json]\n \nrustg:\n[json_encode(toml_output)]")
@@ -24,6 +25,7 @@ var/test_json = @{"
     var/json_value = json_decode(test_json)
     rustg_file_write(rustg_toml_encode(json_value), "tmp/test_encode.toml")
     var/toml_output = rustg_read_toml_file("tmp/test_encode.toml")
+    fdel("tmp/test_encode.toml")
 
     if (toml_output ~! json_value)
         CRASH("test:\n[test_toml]\n \nexpected:\n[test_json]\n \nrustg:\n[json_encode(toml_output)]")


### PR DESCRIPTION
`byondexec` does not exist on windows, and the test runner initializes `bash` unnecessarily. We can now use the `dm` and `dd` binaries directly for better CLI support on Windows. I've also added basic path detection for windows install directories to allow tests to be run directly from VSCode.

All the DM tests run with the rustg repository folder as the main directory, rather than the folder containing the DME. This is counterintuitive and breaks compile->runtime RSC paths for icons, because the change-directory does not apply to files with their paths stored in the RSC. I've added a flag to use the repository root (the previous behavior), currently only the git test uses it, because the git feature always uses `.` as the repository path. I think the only reason the repathing was implemented in the first place was to support this test.

Many tests leave files hanging around that aren't ignored by git, making local test runs problematic. I've added these files to the gitignore and made a `tmp/` directory for use by the tests.

`abc-tests` seems to have a regression on Windows where the regex matches the native TLS block and causes an error. Excluding `#` from the list of allowed characters fixes it.

I also took the liberty of moving some of the DM test code into functions and generally just making it cleaner, since it hasn't been improved properly since 2021.

![image](https://github.com/user-attachments/assets/7a0b7c82-e6cc-497e-a65c-520908db5aa1)
