### PR TITLE
Fix TOML dme test failing

### DIFF
--- a/tests/dm/toml.dme
+++ b/tests/dm/toml.dme
@@ -9,7 +9,7 @@ temp_targets = { cpu = 79, case = 72 }
 "}
 
 var/test_json = @{"
-{"database":{"data":[["delta","phi"]],"enabled":true,"ports":[8000,25565],"temp_targets":{"case":72,"cpu":79}}}
+{"database":{"data":[["delta","phi"]],"enabled":1,"ports":[8000,25565],"temp_targets":{"case":72,"cpu":79}}}
 "}
 
 /test/proc/check_toml_file2json()


### PR DESCRIPTION
I don't know why this has passed CI before, but it should be `1`, not `true` because `json_encode` simply doesn't do that.