### PR TITLE
hash: optimize file hashing

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -153,7 +153,7 @@ impl HashDispatcher {
             "sha256" => Ok(Self::Sha256(Sha256::new())),
             "sha512" => Ok(Self::Sha512(Sha512::new())),
             "xxh64" => Ok(Self::Xxh64(XxHash64::with_seed(XXHASH_SEED))),
-            "xxh64_fixed" => Ok(Self::Xxh64(XxHash64::with_seed(17479268743136991876))),
+            "xxh64_fixed" => Ok(Self::Xxh64(XxHash64::with_seed(17479268743136991876))), // this seed is just a random number that should stay the same between builds and runs
             "base64" => Ok(Self::Base64(Vec::new())),
             _ => Err(Error::InvalidAlgorithm),
         }


### PR DESCRIPTION
This refactors the `hash` module slightly, and optimizes the `rustg_hash_file` function

- I've added a `HashDispatcher` enum, replacing the `hash_algorithm` function, so that we can use `update()` to update the hash with portions of a file easily
  - base64 is handled by just using a buffer, and encoding the entire buffer at the finish
- `file_hash` no longer reads and hashes the entire file at once, instead it reads it in chunks up to 64 KB, updating the hasher with each chunk.
  - the 64 KB buffer is thread-local, instead of being re-allocated with every single file hash.

this should not be a breaking change at all, behavior from the DM side of things / function output should remain completely identical.