### PR TITLE
fix http requests not properly setting the status code

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -124,11 +124,15 @@ fn construct_request(
 }
 
 fn submit_request(prep: RequestPrep) -> Result<String> {
-    let response = prep.req.send_bytes(&prep.body).map_err(Box::new)?;
+    let (status_code, response) = match prep.req.send_bytes(&prep.body) {
+        Ok(response) => (response.status(), response),
+        Err(ureq::Error::Status(status_code, response)) => (status_code, response),
+        Err(err) => return Err(Box::new(err).into()),
+    };
 
     let body;
     let mut resp = Response {
-        status_code: response.status(),
+        status_code,
         headers: HashMap::new(),
         body: None,
     };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d0b19815-5fc4-4d31-ac01-bbf55ae0db56)

the reqwest -> ureq port had a slight whoopsie, non-2xx status code would always error (not setting the `status_code`) field due to how ureq worked, as a non-2xx status code would return an `Err(ureq::Error::Status(status_code, response))` instead of an `Ok(response)`

this fixes that, so that non-2xx status codes will still return the body and such, including setting the status code.