### PR TITLE
Adds `http_request_fire_and_forget`

### DIFF
--- a/dmsrc/http.dm
+++ b/dmsrc/http.dm
@@ -6,5 +6,5 @@
 #define RUSTG_HTTP_METHOD_POST "post"
 #define rustg_http_request_blocking(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_blocking")(method, url, body, headers, options)
 #define rustg_http_request_async(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_async")(method, url, body, headers, options)
-#define rustg_http_request_fire_and_forget(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_async")(method, url, body, headers, options)
+#define rustg_http_request_fire_and_forget(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_fire_and_forget")(method, url, body, headers, options)
 #define rustg_http_check_request(req_id) RUSTG_CALL(RUST_G, "http_check_request")(req_id)

--- a/dmsrc/http.dm
+++ b/dmsrc/http.dm
@@ -6,4 +6,5 @@
 #define RUSTG_HTTP_METHOD_POST "post"
 #define rustg_http_request_blocking(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_blocking")(method, url, body, headers, options)
 #define rustg_http_request_async(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_async")(method, url, body, headers, options)
+#define rustg_http_request_fire_and_forget(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_async")(method, url, body, headers, options)
 #define rustg_http_check_request(req_id) RUSTG_CALL(RUST_G, "http_check_request")(req_id)

--- a/dmsrc/http.dm
+++ b/dmsrc/http.dm
@@ -6,5 +6,7 @@
 #define RUSTG_HTTP_METHOD_POST "post"
 #define rustg_http_request_blocking(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_blocking")(method, url, body, headers, options)
 #define rustg_http_request_async(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_async")(method, url, body, headers, options)
-#define rustg_http_request_fire_and_forget(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_fire_and_forget")(method, url, body, headers, options)
 #define rustg_http_check_request(req_id) RUSTG_CALL(RUST_G, "http_check_request")(req_id)
+/// This is basically just `rustg_http_request_async` if you don't care about the response.
+/// This will either return "ok" or an error, as this does not create a job.
+#define rustg_http_request_fire_and_forget(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_fire_and_forget")(method, url, body, headers, options)

--- a/src/http.rs
+++ b/src/http.rs
@@ -54,6 +54,16 @@ byond_fn!(fn http_request_async(method, url, body, headers, options) {
     }))
 });
 
+byond_fn!(fn http_request_fire_and_forget(method, url, body, headers, options) {
+    let req = match construct_request(method, url, body, headers, options) {
+        Ok(r) => r,
+        Err(e) => return Some(e.to_string())
+    };
+
+    std::thread::spawn(move || req.req.send_bytes(&req.body));
+    Some("ok".to_owned())
+});
+
 // If the response can be deserialized -> success.
 // If the response can't be deserialized -> failure or WIP.
 byond_fn!(fn http_check_request(id) {


### PR DESCRIPTION
This adds `rustg_http_request_fire_and_forget`, which is similar to `rustg_http_request_async`, but it does not return a job ID. It does not use a job at all in fact - it is for when you want to send an HTTP request, and don't give a crap about the response, mostly for POST requests and such.

I couldn't think of a better name, so I'm taking a page from tg's `SSdbcore.FireAndForget`, which does the same thing but for SQL.

I am very much open to better names (I am a bit tired and woozy :3)