### PR TITLE
DMI metadata injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,6 +2865,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_repr",
  "sha-1",
  "sha2",
  "symphonia",
@@ -3051,6 +3052,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ redis = { version = "0.32", optional = true, features = ["ahash"] }
 ureq = { version = "2.12", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
+serde_repr = { version = "0.1", optional = true }
 once_cell = { version = "1.21", optional = true }
 mysql = { git = "https://github.com/ZeWaka/rust-mysql-simple.git", tag = "v26.0.0", default-features = false, optional = true }
 dashmap = { version = "6.1", optional = true, features = ["rayon", "serde"] }
@@ -66,7 +67,11 @@ fast_poisson = { version = "1.0.2", optional = true, features = [
 ] }
 symphonia = { version = "0.5.4", optional = true, features = ["all-codecs"] }
 caith = { version = "4.2.4", optional = true }
-uuid = { version = "1.17", optional = true, features = ["v4", "v7", "fast-rng"] }
+uuid = { version = "1.17", optional = true, features = [
+    "v4",
+    "v7",
+    "fast-rng",
+] }
 cuid2 = { version = "0.1.4", optional = true }
 
 [features]
@@ -127,7 +132,7 @@ all = [
 acreplace = ["aho-corasick"]
 batchnoise = ["dbpnoise"]
 cellularnoise = ["rand", "rayon"]
-dmi = ["png", "image"]
+dmi = ["png", "image", "serde_repr"]
 file = []
 git = ["gix", "chrono"]
 hash = [

--- a/dmsrc/dmi.dm
+++ b/dmsrc/dmi.dm
@@ -7,3 +7,25 @@
  * output: json_encode'd list. json_decode to get a flat list with icon states in the order they're in inside the .dmi
  */
 #define rustg_dmi_icon_states(fname) RUSTG_CALL(RUST_G, "dmi_icon_states")(fname)
+
+/**
+ * Inject dmi metadata into a png file located at `path`
+ *
+ * `metadata` format:
+ * list(
+ *     "width": number,
+ *     "height": number,
+ *     "states": list([STATE_DATA], ...)
+ * )
+ *
+ * STATE_DATA format:
+ * list(
+ *     "name": string,
+ *     "dirs": 1 | 4 | 8,
+ *     "delays"?: list(number, ...),
+ *     "rewind"?: TRUE | FALSE,
+ *     "movement"?: TRUE | FALSE,
+ *     "loop"?: number
+ * )
+ */
+#define rustg_dmi_inject_metadata(path, metadata) RUSTG_CALL(RUST_G, "dmi_inject_metadata")(path, metadata)

--- a/src/dmi.rs
+++ b/src/dmi.rs
@@ -1,8 +1,12 @@
 use crate::error::{Error, Result};
-use png::{Decoder, Encoder, OutputInfo, Reader};
+use png::{text_metadata::ZTXtChunk, Decoder, Encoder, OutputInfo, Reader};
+use serde::Deserialize;
+use serde_repr::Deserialize_repr;
 use std::{
+    fmt::Write,
     fs::{create_dir_all, File},
     io::BufReader,
+    num::NonZeroU32,
     path::Path,
 };
 
@@ -28,6 +32,10 @@ byond_fn!(fn dmi_resize_png(path, width, height, resizetype) {
 
 byond_fn!(fn dmi_icon_states(path) {
     read_states(path).ok()
+});
+
+byond_fn!(fn dmi_inject_metadata(path, metadata) {
+    inject_metadata(path, metadata).err()
 });
 
 fn strip_metadata(path: &str) -> Result<()> {
@@ -145,4 +153,89 @@ fn read_states(path: &str) -> Result<String> {
             });
     }
     Ok(serde_json::to_string(&states)?)
+}
+
+#[derive(Deserialize_repr, Clone, Copy)]
+#[repr(u8)]
+enum DmiStateDirCount {
+    One = 1,
+    Four = 4,
+    Eight = 8,
+}
+
+#[derive(Deserialize)]
+struct DmiState {
+    name: String,
+    dirs: DmiStateDirCount,
+    #[serde(default)]
+    delay: Option<Vec<f32>>,
+    #[serde(default)]
+    rewind: Option<u8>,
+    #[serde(default)]
+    movement: Option<u8>,
+    #[serde(default)]
+    loop_count: Option<NonZeroU32>,
+}
+
+#[derive(Deserialize)]
+struct DmiMetadata {
+    width: u32,
+    height: u32,
+    states: Vec<DmiState>,
+}
+
+fn inject_metadata(path: &str, metadata: &str) -> Result<()> {
+    let read_file = File::open(path).map(BufReader::new)?;
+    let decoder = png::Decoder::new(read_file);
+    let mut reader = decoder.read_info().map_err(|_| Error::InvalidPngData)?;
+    let new_dmi_metadata: DmiMetadata = serde_json::from_str(metadata)?;
+    let mut new_metadata_string = String::new();
+    writeln!(new_metadata_string, "# BEGIN DMI")?;
+    writeln!(new_metadata_string, "version = 4.0")?;
+    writeln!(new_metadata_string, "\twidth = {}", new_dmi_metadata.width)?;
+    writeln!(
+        new_metadata_string,
+        "\theight = {}",
+        new_dmi_metadata.height
+    )?;
+    for state in new_dmi_metadata.states {
+        writeln!(new_metadata_string, "state = \"{}\"", state.name)?;
+        writeln!(new_metadata_string, "\tdirs = {}", state.dirs as u8)?;
+        writeln!(
+            new_metadata_string,
+            "\tframes = {}",
+            state.delay.as_ref().map_or(1, Vec::len)
+        )?;
+        if let Some(delay) = state.delay {
+            writeln!(
+                new_metadata_string,
+                "\tdelay = {}",
+                delay
+                    .iter()
+                    .map(f32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            )?;
+        }
+        if state.rewind.is_some_and(|r| r != 0) {
+            writeln!(new_metadata_string, "\trewind = 1")?;
+        }
+        if state.movement.is_some_and(|m| m != 0) {
+            writeln!(new_metadata_string, "\tmovement = 1")?;
+        }
+        if let Some(loop_count) = state.loop_count {
+            writeln!(new_metadata_string, "\tloop = {}", loop_count)?;
+        }
+    }
+    writeln!(new_metadata_string, "# END DMI")?;
+    let mut info = reader.info().clone();
+    info.compressed_latin1_text
+        .push(ZTXtChunk::new("Description", new_metadata_string));
+    let mut raw_image_data: Vec<u8> = vec![];
+    while let Some(row) = reader.next_row()? {
+        raw_image_data.append(&mut row.data().to_vec());
+    }
+    let encoder = png::Encoder::with_info(File::create(path)?, info)?;
+    encoder.write_header()?.write_image_data(&raw_image_data)?;
+    Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,8 @@ pub enum Error {
     #[cfg(feature = "dice")]
     #[error(transparent)]
     DiceRoll(#[from] caith::RollError),
+    #[error(transparent)]
+    Formatting(#[from] std::fmt::Error),
     #[error("Panic during function execution: {0}")]
     Panic(String),
 }


### PR DESCRIPTION
This PR simply adds a function to inject DMI metadata into a PNG file.

In conjunction with `dmi_create_png`'s new support for alpha channels, it will now be possible to create dmis from user-provided pixel data much more performantly than BYOND's own icon operations.

### Example Usage:
```
var/list/pixels = /* Some list containing 4096 rgba strings - 128 rows of 32 pixels, 32 pixels per row, 32 rows per dir. */
rustg_dmi_create_png("output.dmi", "32", "128", pixels)
var/metadata = json_encode(list(\
  "width" = 32,\
  "height" = 32,\
  "states" = list(\
    list(\
      "name" = "",\
      "dirs" = 4,\
    )\
  )\
)
rustg_dmi_inject_metadata("output.dmi", metadata)
```