### PR TITLE
IconForge: Headless Icon Generation

### DIFF
--- a/dmsrc/iconforge.dm
+++ b/dmsrc/iconforge.dm
@@ -46,6 +46,21 @@
 #define rustg_iconforge_generate(file_path, spritesheet_name, sprites, hash_icons, generate_dmi, flatten) RUSTG_CALL(RUST_G, "iconforge_generate")(file_path, spritesheet_name, sprites, "[hash_icons]", "[generate_dmi]", "[flatten]")
 /// Returns a job_id for use with rustg_iconforge_check()
 #define rustg_iconforge_generate_async(file_path, spritesheet_name, sprites, hash_icons, generate_dmi, flatten) RUSTG_CALL(RUST_G, "iconforge_generate_async")(file_path, spritesheet_name, sprites, "[hash_icons]", "[generate_dmi]", "[flatten]")
+/// Creates a single DMI or PNG using 'sprites' as a list of icon states / images.
+/// This function is intended for generating icons with only a few states that have little in common with each other, and only one size.
+/// For icons with a large number of states, potentially variable sizes, that re-use sets of transforms more than once, or that benefit from caching, use rustg_iconforge_generate.
+/// sprites - follows the same format as rustg_iconforge_generate.
+/// file_path - the full relative path at which the PNG or DMI will be written. It must be a full filepath such as tmp/my_icon.dmi or my_icon.png
+/// flatten - boolean (0 or 1) determines if the DMI output will be flattened to a single frame/dir if unscoped (null/0 dir or frame values).
+///
+/// Returns a HeadlessResult, decoded to a BYOND list (always, it's not possible for this to panic unless rustg itself has an issue) containing the following fields:
+/// list(
+///     "file_path" = "tmp/my_icon.dmi" // [whatever you input returned back to you, null if there was a fatal error]
+///     "width" = 32 // the width, which is determined by the first entry of 'sprites', null if there was a fatal error
+///     "height" = 32 // the height, which is determined by the first entry of 'sprites', null if there was a fatal error
+///     "error" = "[A string, null if there were no errors.]"
+/// )
+#define rustg_iconforge_generate_headless(file_path, sprites, flatten) json_decode(RUSTG_CALL(RUST_G, "iconforge_generate_headless")(file_path, sprites, "[flatten]"))
 /// Returns the status of an async job_id, or its result if it is completed. See RUSTG_JOB DEFINEs.
 #define rustg_iconforge_check(job_id) RUSTG_CALL(RUST_G, "iconforge_check")("[job_id]")
 /// Clears all cached DMIs and images, freeing up memory.

--- a/src/byond.rs
+++ b/src/byond.rs
@@ -123,12 +123,12 @@ pub fn set_panic_hook() {
 #[allow(dead_code)] // Used depending on feature set
 /// Utility for BYOND functions to catch panic unwinds safely and return a Result<String, Error>, as expected.
 /// Usage: catch_panic(|| internal_safe_function(arguments))
-pub fn catch_panic<F>(f: F) -> Result<String, Error>
+pub fn catch_panic<F, R>(f: F) -> Result<R, Error>
 where
-    F: FnOnce() -> Result<String, Error> + std::panic::UnwindSafe,
+    F: FnOnce() -> R + std::panic::UnwindSafe,
 {
     match std::panic::catch_unwind(f) {
-        Ok(o) => o,
+        Ok(o) => Ok(o),
         Err(e) => {
             let message: Option<String> = e
                 .downcast_ref::<&'static str>()

--- a/src/iconforge/byond.rs
+++ b/src/iconforge/byond.rs
@@ -1,5 +1,5 @@
 use super::{gags, image_cache, spritesheet};
-use crate::{byond::catch_panic, jobs};
+use crate::{byond::catch_panic, iconforge::spritesheet::HeadlessResult, jobs};
 use tracy_full::frame;
 
 byond_fn!(fn iconforge_generate(file_path, spritesheet_name, sprites, hash_icons, generate_dmi, flatten) {
@@ -10,7 +10,10 @@ byond_fn!(fn iconforge_generate(file_path, spritesheet_name, sprites, hash_icons
     let generate_dmi = generate_dmi.to_owned();
     let flatten = flatten.to_owned();
     let result = Some(match catch_panic(|| spritesheet::generate_spritesheet(&file_path, &spritesheet_name, &sprites, &hash_icons, &generate_dmi, &flatten)) {
-        Ok(o) => o.to_string(),
+        Ok(o) => match o {
+            Ok(o) => o,
+            Err(e) => e.to_string()
+        },
         Err(e) => e.to_string()
     });
     frame!();
@@ -26,12 +29,38 @@ byond_fn!(fn iconforge_generate_async(file_path, spritesheet_name, sprites, hash
     let flatten = flatten.to_owned();
     Some(jobs::start(move || {
         let result = match catch_panic(|| spritesheet::generate_spritesheet(&file_path, &spritesheet_name, &sprites, &hash_icons, &generate_dmi, &flatten)) {
-            Ok(o) => o.to_string(),
+            Ok(o) => match o {
+                Ok(o) => o,
+                Err(e) => e.to_string()
+            },
             Err(e) => e.to_string()
         };
         frame!();
         result
     }))
+});
+
+byond_fn!(fn iconforge_generate_headless(file_path, sprites, flatten) {
+    let file_path = file_path.to_owned();
+    let sprites = sprites.to_owned();
+    let flatten = flatten.to_owned();
+    let result = Some(match catch_panic::<_, HeadlessResult>(|| spritesheet::generate_headless(&file_path, &sprites, &flatten)) {
+        Ok(o) => match serde_json::to_string::<HeadlessResult>(&o) {
+            Ok(o) => o,
+            Err(_) => String::from("{\"error\":\"Serde serialization error\"}") // nigh impossible but whatever
+        },
+        Err(e) => match serde_json::to_string::<HeadlessResult>(&HeadlessResult {
+            file_path: None,
+            width: None,
+            height: None,
+            error: Some(e.to_string()),
+        }) {
+            Ok(o) => o,
+            Err(_) => String::from("{\"error\":\"Serde serialization error\"}")
+        }
+    });
+    frame!();
+    result
 });
 
 byond_fn!(fn iconforge_check(id) {
@@ -51,7 +80,10 @@ byond_fn!(fn iconforge_cache_valid(input_hash, dmi_hashes, sprites) {
     let dmi_hashes = dmi_hashes.to_owned();
     let sprites = sprites.to_owned();
     let result = Some(match catch_panic(|| spritesheet::cache_valid(&input_hash, &dmi_hashes, &sprites)) {
-        Ok(o) => o.to_string(),
+        Ok(o) => match o {
+            Ok(o) => o,
+            Err(e) => e.to_string()
+        },
         Err(e) => e.to_string()
     });
     frame!();
@@ -64,7 +96,10 @@ byond_fn!(fn iconforge_cache_valid_async(input_hash, dmi_hashes, sprites) {
     let sprites = sprites.to_owned();
     let result = Some(jobs::start(move || {
         match catch_panic(|| spritesheet::cache_valid(&input_hash, &dmi_hashes, &sprites)) {
-            Ok(o) => o.to_string(),
+            Ok(o) => match o {
+                Ok(o) => o,
+                Err(e) => e.to_string()
+            },
             Err(e) => e.to_string()
         }
     }));
@@ -77,7 +112,10 @@ byond_fn!(fn iconforge_load_gags_config(config_path, config_json, config_icon_pa
     let config_json = config_json.to_owned();
     let config_icon_path = config_icon_path.to_owned();
     let result = Some(match catch_panic(|| gags::load_gags_config(&config_path, &config_json, &config_icon_path)) {
-        Ok(o) => o.to_string(),
+        Ok(o) => match o {
+            Ok(o) => o,
+            Err(e) => e.to_string()
+        },
         Err(e) => e.to_string()
     });
     frame!();
@@ -90,7 +128,10 @@ byond_fn!(fn iconforge_load_gags_config_async(config_path, config_json, config_i
     let config_icon_path = config_icon_path.to_owned();
     Some(jobs::start(move || {
         let result = match catch_panic(|| gags::load_gags_config(&config_path, &config_json, &config_icon_path)) {
-            Ok(o) => o.to_string(),
+            Ok(o) => match o {
+                Ok(o) => o,
+                Err(e) => e.to_string()
+            },
             Err(e) => e.to_string()
         };
         frame!();
@@ -103,7 +144,10 @@ byond_fn!(fn iconforge_gags(config_path, colors, output_dmi_path) {
     let colors = colors.to_owned();
     let output_dmi_path = output_dmi_path.to_owned();
     let result = Some(match catch_panic(|| gags::gags(&config_path, &colors, &output_dmi_path)) {
-        Ok(o) => o.to_string(),
+        Ok(o) => match o {
+            Ok(o) => o,
+            Err(e) => e.to_string()
+        },
         Err(e) => e.to_string()
     });
     frame!();
@@ -116,7 +160,10 @@ byond_fn!(fn iconforge_gags_async(config_path, colors, output_dmi_path) {
     let output_dmi_path = output_dmi_path.to_owned();
     Some(jobs::start(move || {
         let result = match catch_panic(|| gags::gags(&config_path, &colors, &output_dmi_path)) {
-            Ok(o) => o.to_string(),
+            Ok(o) => match o {
+                Ok(o) => o,
+                Err(e) => e.to_string()
+            },
             Err(e) => e.to_string()
         };
         frame!();

--- a/src/iconforge/universal_icon.rs
+++ b/src/iconforge/universal_icon.rs
@@ -1,4 +1,4 @@
-use dmi::icon::Looping;
+use dmi::icon::{IconState, Looping};
 use image::DynamicImage;
 use ordered_float::OrderedFloat;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
@@ -133,5 +133,26 @@ impl UniversalIconData {
                 DynamicImage::ImageRgba8(new_image)
             })
             .collect()
+    }
+
+    pub fn to_iconstate(&self, name: &String) -> IconState {
+        let new_delays = Some(
+            self.delay
+                .clone()
+                .unwrap_or_else(|| vec![1.0; self.frames as usize])[0..self.frames as usize]
+                .to_owned(),
+        );
+        IconState {
+            name: name.to_owned(),
+            dirs: self.dirs,
+            frames: self.frames,
+            delay: new_delays,
+            loop_flag: self.loop_flag,
+            rewind: self.rewind,
+            movement: false,
+            unknown_settings: Option::None,
+            hotspot: Option::None,
+            images: self.images.to_vec(),
+        }
     }
 }

--- a/tests/dm/iconforge.dme
+++ b/tests/dm/iconforge.dme
@@ -147,6 +147,22 @@
 		src.transform.apply(self)
 	return self
 
+/// Convert the universal icon into a DM icon using rust-backed IconForge generation.
+/// The resulting DM icon is unscoped but contains one icon state with '[output_icon_state_name]' as its name.
+/// Returns null and runtimes if there is any fatal errors. Non-fatal errors will emit a runtime but provide an icon.
+/datum/universal_icon/proc/to_icon_headless(file_path, output_icon_state_name)
+	. = null
+	if(!istext(file_path) || !length(file_path))
+		return
+	var/list/result = rustg_iconforge_generate_headless(file_path, json_encode(list("[output_icon_state_name]" = src.to_list())), FALSE)
+	if(!islist(result))
+		CRASH("Unparseable result from rustg_iconforge_generate_headless for '[file_path]': [result]")
+	if(result["file_path"] != file_path)
+		CRASH("Fatal errors during rustg_iconforge_generate_headless for '[file_path]': [result["error"]]")
+	. = icon(file(file_path))
+	if(!isnull(result["error"]) && length(result["error"]))
+		CRASH("Errors during rustg_iconforge_generate_headless for '[file_path]': [result["error"]]")
+
 /datum/icon_transformer
 	var/list/transforms = null
 
@@ -602,6 +618,29 @@
 	while(!check_jobs(job_ids)) sleep(-1)
 	duration = rustg_time_milliseconds("iconforge_rustg")
 	world.log << "rustg: Elapsed [duration]ms\n"
+	world.log << "Generating rustg sheets (headless mode)..."
+	rustg_time_reset("iconforge_rustg_headless")
+	for(var/expected_size in sizes)
+		var/list/uni_icons = sizes[expected_size]
+		var/list/entries = list()
+		for(var/entry_name as anything in uni_icons)
+			var/datum/universal_icon/entry = uni_icons[entry_name]
+			entries[entry_name] = entry.to_list()
+		var/entries_json = json_encode(entries)
+		var/file_path = "tmp/headless_iconforge_rustg_[expected_size].dmi"
+		var/list/result = rustg_iconforge_generate_headless(file_path, entries_json, FALSE)
+		if(!islist(result))
+			world.log << "runtime error: Unparseable result from rustg_iconforge_generate_headless for '[file_path]': [result]"
+			continue
+		if(result["file_path"] != file_path)
+			world.log << "runtime error: Fatal errors during rustg_iconforge_generate_headless for '[file_path]': [result["error"]]"
+			continue
+		if(!isnull(result["error"]) && length(result["error"]))
+			world.log << "runtime error: Errors during rustg_iconforge_generate_headless for '[file_path]': [result["error"]]"
+			continue
+
+	duration = rustg_time_milliseconds("iconforge_rustg_headless")
+	world.log << "rustg (headless): Elapsed [duration]ms\n"
 
 /proc/check_jobs(list/job_ids)
 	for(var/job in job_ids)
@@ -628,6 +667,49 @@
 			world.log << "runtime error: Invalid size output from rustg (expected: [expected_size], got: [sizes_joined])"
 		job_ids -= job
 	return TRUE
+
+/proc/headless_must_error(file_path, sprites, error_text)
+	var/list/result = rustg_iconforge_generate_headless(file_path, sprites, FALSE)
+	if(!islist(result))
+		world.log << "runtime error: Unparseable result from rustg_iconforge_generate_headless for '[file_path]': [result]"
+	if(result["file_path"] == file_path)
+		world.log << "runtime error: rustg_iconforge_generate_headless output file_path when an error was expected ([error_text])"
+	if(!isnull(result["error"]) && length(result["error"]))
+		world.log << "error test PASS: [error_text] \n---->    [result["error"]]\n\n"
+	else
+		world.log << "runtime error: rustg_iconforge_generate_headless output no errors when an error was expected ([error_text])"
+
+/test/proc/headless_error_handling()
+	var/datum/universal_icon/valid = uni_icon('rsc/iconforge_tests.dmi', "dirs_1_frames_1", SOUTH, 1)
+	valid.blend_color("#fc00fc", ICON_MULTIPLY)
+	var/datum/universal_icon/valid_64 = uni_icon('rsc/iconforge_tests.dmi', "dirs_1_frames_1", SOUTH, 1)
+	valid_64.scale(64, 64)
+	var/valid_json = json_encode(list("test" = valid.to_list()))
+	headless_must_error("", valid_json, "empty filename")
+	headless_must_error("tmp/nonexistent.jpg", valid_json, "invalid file extension")
+	headless_must_error("tmp/nonexistent", valid_json, "no file extension")
+	headless_must_error("/../what.dmi", valid_json, "invalid file path")
+	headless_must_error("tmp/nonexistent.dmi", "{}", "no sprites")
+	headless_must_error("tmp/nonexistent.dmi", "lol", "invalid sprites")
+	headless_must_error("tmp/nonexistent.dmi", json_encode(list("test" = list("lol" = 1))), "invalid sprites content")
+	var/list/mixed_size_result = rustg_iconforge_generate_headless("tmp/iconforge_mixed_sizes.dmi", json_encode(list("32" = valid.to_list(), "64" = valid_64.to_list())), FALSE)
+	if(mixed_size_result["width"] != 32 && mixed_size_result["height"] != 32)
+		world.log << "runtime error: Mixed-sizes headless generation test did not give a 32x32 icon (the first value passed) [mixed_size_result["error"]]"
+	if(length(icon_states(icon(file("tmp/iconforge_mixed_sizes.dmi")))) != 1)
+		world.log << "runtime error: Mixed-sizes headless generation test gave more than one state, when it should only contain states with correct sizes [mixed_size_result["error"]]"
+	var/datum/universal_icon/nonexistent_icon = uni_icon("nonexistent", "nonexistent")
+	headless_must_error("tmp/nonexistent.dmi", json_encode(list("test" = nonexistent_icon.to_list())), "nonexistent icon file")
+	var/datum/universal_icon/nonexistent_state = uni_icon('rsc/iconforge_tests.dmi', "nonexistent")
+	headless_must_error("tmp/nonexistent.dmi", json_encode(list("test" = nonexistent_state.to_list())), "nonexistent icon state")
+	var/datum/universal_icon/nonexistent_dir = uni_icon('rsc/iconforge_tests.dmi', "dirs_1_frames_1", NORTH)
+	headless_must_error("tmp/nonexistent.dmi", json_encode(list("test" = nonexistent_dir.to_list())), "nonexistent dir")
+	var/datum/universal_icon/nonexistent_frame = uni_icon('rsc/iconforge_tests.dmi', "dirs_1_frames_1", SOUTH, 2)
+	headless_must_error("tmp/nonexistent.dmi", json_encode(list("test" = nonexistent_frame.to_list())), "nonexistent frame")
+	var/icon/valid_icon = valid.to_icon_headless("tmp/iconforge_valid_headless.dmi", "")
+	if(!isicon(valid_icon))
+		world.log << "runtime error: failed to generate headless icon that is valid!"
+	// Copy a scoped version into a new dmi for comparison
+	fcopy(icon(valid_icon, ""), "tmp/iconforge_valid_headless_copied.dmi")
 
 
 #undef uni_icon


### PR DESCRIPTION
Adds a new headless generation system to IconForge via `rustg_iconforge_generate_headless`:

```dm
/// Creates a single DMI or PNG using 'sprites' as a list of icon states / images.
/// This function is intended for generating icons with only a few states that have little in common with each other, and only one size.
/// For icons with a large number of states, potentially variable sizes, that re-use sets of transforms more than once, or that benefit from caching, use rustg_iconforge_generate.
/// sprites - follows the same format as rustg_iconforge_generate.
/// file_path - the full relative path at which the PNG or DMI will be written. It must be a full filepath such as tmp/my_icon.dmi or my_icon.png
/// flatten - boolean (0 or 1) determines if the DMI output will be flattened to a single frame/dir if unscoped (null/0 dir or frame values).
///
/// Returns a HeadlessResult, decoded to a BYOND list (always, it's not possible for this to panic unless rustg itself has an issue) containing the following fields:
/// list(
///     "file_path" = "tmp/my_icon.dmi" // [whatever you input returned back to you, null if there was a fatal error]
///     "width" = 32 // the width, which is determined by the first entry of 'sprites', null if there was a fatal error
///     "height" = 32 // the height, which is determined by the first entry of 'sprites', null if there was a fatal error
///     "error" = "[A string, null if there were no errors.]"
/// )
#define rustg_iconforge_generate_headless(file_path, sprites, flatten) json_decode(RUSTG_CALL(RUST_G, "iconforge_generate_headless")(file_path, sprites, "[flatten]"))
```

This system is intended for generating icons with only a few states that have little in common with each other, and only one size, as opposed to the traditional generation which is suitable for large batches that re-use icons regularly.

The new function is suitable for creating drop-in replacement for one-time icon operations and could be used for something like generating a minimap with DrawBox. Speed relative to native BYOND icons is not guaranteed due to the I/O cost and less optimization / caching, but it's likely to be faster for icons that are built with a large number of transforms in sequence, because it doesn't resolve the icon until it's converted.

Also fixes a bug where flattened icons could pollute the cache with incorrect data by splitting the caches for flattened and non-flattened icons.

Adds error-tests for icon generation using the new headless generator, checking for common error cases. Also tests headless generation for consistency with BYOND and regular batch generation.