### PR TITLE
makes `rustg_noise_poisson_map` around 8x faster

### DIFF
--- a/src/poissonnoise.rs
+++ b/src/poissonnoise.rs
@@ -1,7 +1,6 @@
-use fast_poisson::Poisson2D;
-use std::fmt::Write;
-
 use crate::error::Result;
+use fast_poisson::Poisson2D;
+use std::collections::HashSet;
 
 byond_fn!(fn noise_poisson_map(seed, width, length, radius) {
     get_poisson_map(seed, width, length, radius).ok()
@@ -13,26 +12,25 @@ fn get_poisson_map(
     length_as_str: &str,
     radius_as_str: &str,
 ) -> Result<String> {
-    let width = width_as_str.parse::<f32>()?;
-    let length = length_as_str.parse::<f32>()?;
+    let width = width_as_str.parse::<usize>()?;
+    let length = length_as_str.parse::<usize>()?;
     let radius = radius_as_str.parse::<f32>()?;
     let seed = seed_as_str.parse::<u64>()?;
 
-    let points: Vec<[f32; 2]> = Poisson2D::new()
-        .with_dimensions([width, length], radius)
+    let points: HashSet<(usize, usize)> = Poisson2D::new()
+        .with_dimensions([width as f32, length as f32], radius)
         .with_seed(seed)
-        .to_vec();
+        .iter()
+        .map(|[x, y]| (x as usize, y as usize))
+        .collect();
 
-    let mut output = String::new();
-    for y in 0..length as usize {
-        for x in 0..width as usize {
-            if points
-                .iter()
-                .any(|&point| point[0] as usize == x && point[1] as usize == y)
-            {
-                let _ = write!(output, "1");
+    let mut output = String::with_capacity(width * length);
+    for y in 0..length {
+        for x in 0..width {
+            if points.contains(&(x, y)) {
+                output.push('1');
             } else {
-                let _ = write!(output, "0");
+                output.push('0');
             }
         }
     }


### PR DESCRIPTION
## before
<img width="772" height="413" alt="2025-11-05 (1762331026) ~ tracy-profiler" src="https://github.com/user-attachments/assets/13987d12-b803-41fc-bf64-ad377b5ebde5" />

## after
<img width="765" height="407" alt="2025-11-05 (1762332229) ~ tracy-profiler" src="https://github.com/user-attachments/assets/c54abb73-4b57-4183-a1b7-db00c854e657" />

(both of these were with 255 width/height and a radius of 6)

---

so it turns out doing W x H `O(n)` lookups while also reallocating the string a morbillion times is not exactly good for performance.

instead, we pre-allocate a string with the right capacity, and use `string.push` instead of using the `std::fmt` stuff.
we also convert the noise points to a HashSet, so it's an `O(1)` lookup for each coordinate instead of `O(n)`.
could prolly be improved further but meh this is still _SO_ much better.