### PR TITLE
Handle errors in panic hook explicitly

### DIFF
--- a/src/byond.rs
+++ b/src/byond.rs
@@ -100,7 +100,7 @@ pub fn set_panic_hook() {
     SET_HOOK.call_once(|| {
         let default_panic_handler = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |panic_info| {
-            default_panic_handler(&panic_info);
+            default_panic_handler(panic_info);
             let mut file = match OpenOptions::new()
                 .append(true)
                 .create(true)
@@ -138,7 +138,6 @@ pub fn set_panic_hook() {
                 Ok(_) => {}
                 Err(err) => {
                     eprintln!("panic_hook: Failed to extract backtrace: {err:?}");
-                    return;
                 }
             };
         }))


### PR DESCRIPTION
Removes `unwrap` and `expect` from our panic handler. Any panics that happen during an active panic will force rust-g to call abort(3) on DreamDaemon which is what I suspect to be the cause of a lot of inexplicable crashes on tgstation recently.

Additionally, use the default hook handler by getting it with `take_hook` and calling it in our panic handler. The default handler writes the error to stderr which is useful debug information if writing to `rustg-panic.log` fails