### PR TITLE
new feature `ed25519` for pubkey signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +502,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +620,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,9 +679,9 @@ checksum = "69dde51e8fef5e12c1d65e0929b03d66e4c0c18282bc30ed2ca050ad6f44dd82"
 
 [[package]]
 name = "dmi"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ffa0925bc72c58722f7b0f615f561ed98d4bf09754415383764c4888f2671c"
+checksum = "26164ec9cc4d88eadf50af4cd6470372df610e75e1f3a6a4e5d6c671b9a5b742"
 dependencies = [
  "bitflags 2.11.0",
  "crc32fast",
@@ -663,6 +712,30 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -760,6 +833,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -2547,6 +2626,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -2964,6 +3053,7 @@ dependencies = [
  "dashmap",
  "dbpnoise",
  "dmi",
+ "ed25519-dalek",
  "fast_poisson",
  "flume",
  "gix",
@@ -2981,7 +3071,7 @@ dependencies = [
  "percent-encoding",
  "png",
  "qrcode",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "redis",
@@ -2999,6 +3089,7 @@ dependencies = [
  "ureq",
  "url",
  "uuid",
+ "zeroize",
  "zip",
 ]
 
@@ -3290,6 +3381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3968,7 +4078,7 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.1",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ once_cell = { version = "1.21", optional = true }
 mysql = { git = "https://github.com/ZeWaka/rust-mysql-simple.git", tag = "v26.0.0", default-features = false, optional = true }
 dashmap = { version = "6.1", optional = true, features = ["rayon", "serde"] }
 zip = { version = "8.2", optional = true }
-rand = { version = "0.10", optional = true, features = ["sys_rng"]}
+rand = { version = "0.10.1", optional = true, features = ["sys_rng"]}
 toml-dep = { version = "1.0.7", package = "toml", optional = true }
 aho-corasick = { version = "1.1", optional = true }
 rayon = { version = "1.11", optional = true }
@@ -60,6 +60,7 @@ dbpnoise = { version = "0.1.2", optional = true }
 pathfinding = { version = "4.15", optional = true }
 num-integer = { version = "0.1.46", optional = true }
 dmi = { version = "0.5.0", optional = true }
+ed25519-dalek = { version = "2.2", optional = true }
 tracy_full = { version = "1.12.0", optional = true }
 ammonia = { version = "4.1", optional = true }
 fast_poisson = { version = "1.0.2", optional = true, features = [
@@ -82,6 +83,7 @@ indexmap = { version = "2.13.0", optional = true, features = [
 ] }
 ordered-float = { version = "5.1.0", optional = true, features = ["serde"] }
 qrcode = { version = "0.14.1", optional = true, features = ["image", "svg"]}
+zeroize = { version = "1.8", optional = true }
 
 [features]
 default = [
@@ -114,6 +116,7 @@ all = [
     "cellularnoise",
     "dmi",
     "dice",
+    "ed25519",
     "file",
     "git",
     "hash",
@@ -189,6 +192,7 @@ uuid = ["dep:uuid", "cuid2"]
 
 # additional features
 dice = ["caith"]
+ed25519 = ["base64", "ed25519-dalek", "rand", "zeroize"]
 pathfinder = ["num-integer", "pathfinding", "serde", "serde_json"]
 poissonnoise = ["fast_poisson"]
 redis_pubsub = ["flume", "redis", "serde", "serde_json"]

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Additional features are:
 * allow_non_32bit: Disables the forced compile errors on non-32bit targets. Only use this if you know exactly what you are doing.
 * batchnoise: Discrete Batched Perlin-like Noise, fast and multi-threaded - sent over once instead of having to query for every tile.
 * dice: Advanced replacement for `roll`, supporting expressive xdy dice notation.
+* ed25519: Ed25519 key generation, public key derivation, signing, and signature verification.
 * poissonnoise: A way to generate a 2D poisson disk distribution ('blue noise'), which is relatively uniform.
 * redis_pubsub: Library for sending and receiving messages through Redis.
 * redis_reliablequeue: Library for using a reliable queue pattern through Redis.

--- a/dmsrc/ed25519.dm
+++ b/dmsrc/ed25519.dm
@@ -1,0 +1,15 @@
+/// Generates 32-byte Ed25519 signing key, encoded as standard base64.
+/// Returns raw key bytes. Not PEM or PKCS8.
+#define rustg_ed25519_generate_secret_key(...) RUSTG_CALL(RUST_G, "ed25519_generate_secret_key")()
+
+/// Derives Ed25519 public key from base64-encoded 32-byte `secret_key`.
+/// Returns base64-encoded raw 32-byte public key, or `ERROR: ...`.
+#define rustg_ed25519_derive_public_key(secret_key) RUSTG_CALL(RUST_G, "ed25519_derive_public_key")(secret_key)
+
+/// Signs `message` bytes with `secret_key`.
+/// Returns base64-encoded raw 64-byte signature, or `ERROR: ...`.
+#define rustg_ed25519_sign(secret_key, message) RUSTG_CALL(RUST_G, "ed25519_sign")(secret_key, message)
+
+/// Verifies Ed25519 `signature` over `message` bytes against `public_key`.
+/// Returns `"true"`, `"false"`, or `ERROR: ...`.
+#define rustg_ed25519_verify(public_key, message, signature) RUSTG_CALL(RUST_G, "ed25519_verify")(public_key, message, signature)

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -1,0 +1,182 @@
+use crate::error::{Error, Result};
+use base64::{Engine, prelude::BASE64_STANDARD};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use zeroize::Zeroize;
+
+const ED25519_SECRET_KEY_LEN: usize = 32;
+const ED25519_PUBLIC_KEY_LEN: usize = 32;
+const ED25519_SIGNATURE_LEN: usize = 64;
+
+byond_fn!(
+    fn ed25519_generate_secret_key() {
+        Some(generate_ed25519_secret_key())
+    }
+);
+
+byond_fn!(fn ed25519_derive_public_key(secret_key) {
+    match derive_ed25519_public_key(secret_key) {
+        Ok(public_key) => Some(public_key),
+        Err(error) => Some(format!("ERROR: {error}")),
+    }
+});
+
+byond_fn!(fn ed25519_sign(secret_key, message) {
+    match sign_ed25519(secret_key, message.as_bytes()) {
+        Ok(signature) => Some(signature),
+        Err(error) => Some(format!("ERROR: {error}")),
+    }
+});
+
+byond_fn!(fn ed25519_verify(public_key, message, signature) {
+    match verify_ed25519(public_key, message.as_bytes(), signature) {
+        Ok(is_valid) => Some(is_valid.to_string()),
+        Err(error) => Some(format!("ERROR: {error}")),
+    }
+});
+
+pub fn generate_ed25519_secret_key() -> String {
+    let mut secret_key = [0u8; ED25519_SECRET_KEY_LEN];
+    rand::fill(&mut secret_key[..]);
+    let encoded = BASE64_STANDARD.encode(secret_key);
+    secret_key.zeroize();
+    encoded
+}
+
+pub fn derive_ed25519_public_key(secret_key_b64: &str) -> Result<String> {
+    let signing_key = decode_ed25519_signing_key(secret_key_b64)?;
+    Ok(BASE64_STANDARD.encode(signing_key.verifying_key().to_bytes()))
+}
+
+pub fn sign_ed25519(secret_key_b64: &str, message: &[u8]) -> Result<String> {
+    let signing_key = decode_ed25519_signing_key(secret_key_b64)?;
+    let signature = signing_key.sign(message);
+    Ok(BASE64_STANDARD.encode(signature.to_bytes()))
+}
+
+pub fn verify_ed25519(public_key_b64: &str, message: &[u8], signature_b64: &str) -> Result<bool> {
+    let verifying_key = decode_ed25519_verifying_key(public_key_b64)?;
+    let signature = decode_ed25519_signature(signature_b64)?;
+    Ok(verifying_key.verify_strict(message, &signature).is_ok())
+}
+
+fn decode_ed25519_signing_key(secret_key_b64: &str) -> Result<SigningKey> {
+    let mut decoded = BASE64_STANDARD.decode(secret_key_b64)?;
+    let actual = decoded.len();
+    if actual != ED25519_SECRET_KEY_LEN {
+        decoded.zeroize();
+        return Err(Error::InvalidEd25519Length {
+            kind: "secret key",
+            expected: ED25519_SECRET_KEY_LEN,
+            actual,
+        });
+    }
+
+    let mut secret_key = [0u8; ED25519_SECRET_KEY_LEN];
+    secret_key.copy_from_slice(&decoded);
+    decoded.zeroize();
+
+    let signing_key = SigningKey::from_bytes(&secret_key);
+    secret_key.zeroize();
+    Ok(signing_key)
+}
+
+fn decode_ed25519_verifying_key(public_key_b64: &str) -> Result<VerifyingKey> {
+    let decoded = BASE64_STANDARD.decode(public_key_b64)?;
+    let public_key: [u8; ED25519_PUBLIC_KEY_LEN] =
+        decoded
+            .try_into()
+            .map_err(|decoded: Vec<u8>| Error::InvalidEd25519Length {
+                kind: "public key",
+                expected: ED25519_PUBLIC_KEY_LEN,
+                actual: decoded.len(),
+            })?;
+    Ok(VerifyingKey::from_bytes(&public_key)?)
+}
+
+fn decode_ed25519_signature(signature_b64: &str) -> Result<Signature> {
+    let decoded = BASE64_STANDARD.decode(signature_b64)?;
+    if decoded.len() != ED25519_SIGNATURE_LEN {
+        return Err(Error::InvalidEd25519Length {
+            kind: "signature",
+            expected: ED25519_SIGNATURE_LEN,
+            actual: decoded.len(),
+        });
+    }
+    Ok(Signature::from_slice(&decoded)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ed25519_round_trip() {
+        let secret_key = generate_ed25519_secret_key();
+        let public_key = derive_ed25519_public_key(&secret_key).unwrap();
+        let message = b"rust-g ed25519 test";
+        let signature = sign_ed25519(&secret_key, message).unwrap();
+
+        assert!(verify_ed25519(&public_key, message, &signature).unwrap());
+        assert!(!verify_ed25519(&public_key, b"rust-g ed25519 toast", &signature).unwrap());
+    }
+
+    #[test]
+    fn ed25519_matches_rfc8032() {
+        // https://datatracker.ietf.org/doc/html/rfc8032#section-7.1
+        let secret_key1 = BASE64_STANDARD.encode(decode_hex(
+            "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+        ));
+        let public_key1 = BASE64_STANDARD.encode(decode_hex(
+            "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+        ));
+        let signature1 = BASE64_STANDARD.encode(decode_hex(
+            "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b",
+        ));
+
+        assert_eq!(
+            derive_ed25519_public_key(&secret_key1).unwrap(),
+            public_key1
+        );
+        assert_eq!(sign_ed25519(&secret_key1, b"").unwrap(), signature1);
+        assert!(verify_ed25519(&public_key1, b"", &signature1).unwrap());
+
+        let secret_key2 = BASE64_STANDARD.encode(decode_hex(
+            "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb",
+        ));
+        let public_key2 = BASE64_STANDARD.encode(decode_hex(
+            "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+        ));
+        let signature2 = BASE64_STANDARD.encode(decode_hex(
+            "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00",
+        ));
+
+        assert_eq!(
+            derive_ed25519_public_key(&secret_key2).unwrap(),
+            public_key2
+        );
+        assert_eq!(sign_ed25519(&secret_key2, b"r").unwrap(), signature2);
+        assert!(verify_ed25519(&public_key2, b"r", &signature2).unwrap());
+    }
+
+    #[test]
+    fn invalid_secret_key_length_errors() {
+        let error = derive_ed25519_public_key(&BASE64_STANDARD.encode([0u8; 31])).unwrap_err();
+        assert!(matches!(
+            error,
+            Error::InvalidEd25519Length {
+                kind: "secret key",
+                expected: ED25519_SECRET_KEY_LEN,
+                actual: 31,
+            }
+        ));
+    }
+
+    // I don't really want to load the hex dep
+    fn decode_hex(input: &str) -> Vec<u8> {
+        input
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|chunk| u8::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16).unwrap())
+            .collect()
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,8 +76,22 @@ pub enum Error {
     DiceRoll(#[from] caith::RollError),
     #[error(transparent)]
     Formatting(#[from] std::fmt::Error),
+    #[cfg(any(feature = "dmi", feature = "iconforge"))]
     #[error(transparent)]
     Dmi(#[from] dmi::error::DmiError),
+    #[cfg(feature = "ed25519")]
+    #[error(transparent)]
+    Base64Decode(#[from] base64::DecodeError),
+    #[cfg(feature = "ed25519")]
+    #[error(transparent)]
+    Ed25519(#[from] ed25519_dalek::SignatureError),
+    #[cfg(feature = "ed25519")]
+    #[error("Invalid ed25519 {kind} length: expected {expected} bytes, got {actual}.")]
+    InvalidEd25519Length {
+        kind: &'static str,
+        expected: usize,
+        actual: usize,
+    },
     #[error("Panic during function execution: {0}")]
     Panic(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// #![forbid(unsafe_op_in_unsafe_fn)] - see github.com/rust-lang/rust/issues/121483
+#![forbid(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(
     all(windows, not(all(target_vendor = "pc", target_env = "msvc"))),
     allow(clippy::missing_const_for_thread_local)
@@ -22,6 +22,8 @@ pub mod dbpnoise;
 pub mod dice;
 #[cfg(feature = "dmi")]
 pub mod dmi;
+#[cfg(feature = "ed25519")]
+pub mod ed25519;
 #[cfg(feature = "file")]
 pub mod file;
 #[cfg(feature = "git")]

--- a/tests/dm-tests.rs
+++ b/tests/dm-tests.rs
@@ -2,10 +2,28 @@ use std::fs;
 use std::path::Path;
 use std::process::{Command, Output};
 
+#[cfg(feature = "dice")]
+#[test]
+fn dice() {
+    run_dm_tests("dice", false);
+}
+
+#[cfg(feature = "ed25519")]
+#[test]
+fn ed25519() {
+    run_dm_tests("ed25519", false);
+}
+
 #[cfg(feature = "git")]
 #[test]
 fn git() {
     run_dm_tests("git", true);
+}
+
+#[cfg(feature = "hash")]
+#[test]
+fn hash() {
+    run_dm_tests("hash", false);
 }
 
 #[cfg(feature = "toml")]
@@ -18,18 +36,6 @@ fn toml() {
 #[test]
 fn url() {
     run_dm_tests("url", false);
-}
-
-#[cfg(feature = "hash")]
-#[test]
-fn hash() {
-    run_dm_tests("hash", false);
-}
-
-#[cfg(feature = "dice")]
-#[test]
-fn dice() {
-    run_dm_tests("dice", false);
 }
 
 #[cfg(feature = "iconforge")]

--- a/tests/dm/ed25519.dme
+++ b/tests/dm/ed25519.dme
@@ -1,0 +1,25 @@
+#include "common.dm"
+
+/test/proc/ed25519_round_trip()
+    var/secret_key = rustg_ed25519_generate_secret_key()
+    var/public_key = rustg_ed25519_derive_public_key(secret_key)
+    if (findtextEx(public_key, "ERROR: "))
+        CRASH("Failed to derive public key: [public_key]")
+
+    var/message = "rust-g test message"
+    var/signature = rustg_ed25519_sign(secret_key, message)
+    if (findtextEx(signature, "ERROR: "))
+        CRASH("Failed to sign message: [signature]")
+
+    var/valid = rustg_ed25519_verify(public_key, message, signature)
+    if (valid != "true")
+        CRASH("Expected valid signature, got: [valid]")
+
+    var/invalid = rustg_ed25519_verify(public_key, "[message]!!!!!", signature)
+    if (invalid != "false")
+        CRASH("Expected invalid signature, got: [invalid]")
+
+/test/proc/ed25519_bad_inputs_error()
+    var/invalid_public = rustg_ed25519_derive_public_key("rust-g")
+    if (!findtextEx(invalid_public, "ERROR: "))
+        CRASH("Expected invalid secret key error, got: [invalid_public]")


### PR DESCRIPTION
Adds an ed25519 module to generate public/private keys and sign messages.

API:
```dm
/// Generates 32-byte Ed25519 signing key, encoded as standard base64.
/// Returns raw key bytes. Not PEM or PKCS8.
#define rustg_ed25519_generate_secret_key(...) RUSTG_CALL(RUST_G, "ed25519_generate_secret_key")()

/// Derives Ed25519 public key from base64-encoded 32-byte `secret_key`.
/// Returns base64-encoded raw 32-byte public key, or ``ERROR: ...``.
#define rustg_ed25519_derive_public_key(secret_key) RUSTG_CALL(RUST_G, "ed25519_derive_public_key")(secret_key)

/// Signs `message` bytes with `secret_key`.
/// Returns base64-encoded raw 64-byte signature, or ``ERROR: ...``.
#define rustg_ed25519_sign(secret_key, message) RUSTG_CALL(RUST_G, "ed25519_sign")(secret_key, message)

/// Verifies Ed25519 `signature` over `message` bytes against `public_key`.
/// Returns `"true"`, `"false"`, or ``ERROR: ...``.
#define rustg_ed25519_verify(public_key, message, signature) RUSTG_CALL(RUST_G, "ed25519_verify")(public_key, message, signature)
```