### PR TITLE
adds configurations  and a README entry for debugging

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"ms-vscode.cpptools",
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "configurations": [
+    {
+        "name": "Attach to Dreamseeker (MSVC)",
+        "type": "cppvsdbg",
+        "request": "attach",
+        "processId": "${command:pickProcess}",
+        "symbolSearchPath": "${workspaceFolder}/target/i686-pc-windows-msvc/debug"
+    },
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
 	"version": "2.0.0",
 	"tasks": [
         {
-            "label": "rust: cargo build (win32)",
+            "label": "rust: cargo development build (win32)",
             "args": [
                 "build",
                 "--target",
@@ -15,9 +15,39 @@
             "group": "build"
         },
         {
-            "label": "rust: cargo build (win32, all features)",
+            "label": "rust: cargo development build (win32, all features)",
             "args": [
                 "build",
+                "--target",
+                "i686-pc-windows-msvc",
+                "--features",
+                "all",
+            ],
+            "command": "cargo",
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": "build"
+        },
+        {
+            "label": "rust: cargo release build (win32)",
+            "args": [
+                "build",
+                "--release",
+                "--target",
+                "i686-pc-windows-msvc",
+            ],
+            "command": "cargo",
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": "build"
+        },
+        {
+            "label": "rust: cargo release build (win32, all features)",
+            "args": [
+                "build",
+                "--release",
                 "--target",
                 "i686-pc-windows-msvc",
                 "--features",

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cargo build --release --target i686-unknown-linux-gnu
 
 Windows:
 
-If you are using Visual Studio Code, you may use the `CONTROL + SHIFT + B` hotkey and run the `rust: cargo build (win32)` task.
+If you are using Visual Studio Code, you may use the `CONTROL + SHIFT + B` hotkey and run the `rust: cargo release build (win32)` task.
 
 Alternatively:
 ```sh
@@ -135,6 +135,16 @@ of the enabled modules. To use rust-g, copy-paste this file into your project.
 
 `rust_g.dm` can be configured by creating a `rust_g.config.dm`. See the comments
 at the top of `rust_g.dm` for details.
+
+## Debugging
+
+### Windows, Visual Studio Code
+
+In order to debug the library, you must have the [Microsoft C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) (`ms-vscode.cpptools`) installed and enabled. Compile the library in development mode, either via pressing `CONTROL + SHIFT + B` and running the `rust: cargo development build (win32)` task, or running the command `cargo build --target i686-pc-windows-msvc` in the terminal. In either way, the debug compiled library will be available in `target/i686-pc-windows-msvc/debug`.
+
+Next, move the compiled debug library to your project. After starting your server, pressing F5 in the rust-g project workspace will open a dialogue window asking you to select a process. Search for the dreamseeker instance and select it; this will attach the debugger to it, allowing you to debug the library.
+
+**Note:** Due to the way the MSVC behaves, sometimes the debugger struggles with matching the lines in the source code to the code running on the server. This seems to be caused by the way rust inlines its macros. If you notice any strange breakpoint behavior on your functions, try clicking on the `byond_fn!` macro and press `ctrl+.`, and select `Inline macro`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
To make it easier for other in the future to debug this library, I've added a few json entries and a README entry about how to debug it.

I've also added entries in the `tasks.json` file to allow for compiling in development mode (no compiler optimizations) and in release mode (with compiler optimizations).

I also added the `ms-vscode.cpptools` VSC extension to the list of recommended extensions to make it easier to access it for debugging.